### PR TITLE
Bump libs add gost94ua

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,13 +13,13 @@ dependencies = [
 
 [[package]]
 name = "argon2"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1574351abf0e4ef0de867b083a9f8e2f13618efcad6d3253c53554e4a887ed5"
+checksum = "a27e27b63e4a34caee411ade944981136fdfa535522dc9944d6700196cbd899f"
 dependencies = [
  "base64ct",
- "blake2 0.10.0",
- "password-hash 0.3.2",
+ "blake2",
+ "password-hash",
 ]
 
 [[package]]
@@ -47,32 +47,11 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "blake2"
-version = "0.9.2"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a4e37d16930f5459780f5621038b6382b9bb37c19016f39fb6b5808d831f174"
+checksum = "b9cf849ee05b2ee5fba5e36f97ff8ec2533916700fc0758d40d92136a42f3388"
 dependencies = [
- "crypto-mac 0.8.0",
- "digest 0.9.0",
- "opaque-debug",
-]
-
-[[package]]
-name = "blake2"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a58bdf5134c5beae6fc382002c4d88950bad1feea20f8f7165494b6b43b049de"
-dependencies = [
- "digest 0.10.1",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
-dependencies = [
- "block-padding",
- "generic-array",
+ "digest",
 ]
 
 [[package]]
@@ -85,18 +64,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "block-padding"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
-
-[[package]]
-name = "byteorder"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -104,11 +71,12 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cipher"
-version = "0.3.0"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
+checksum = "d1873270f8f7942c191139cb8a40fd228da6c3fd2fc376d7e92d47aa14aeb59e"
 dependencies = [
- "generic-array",
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -137,51 +105,22 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d6b536309245c849479fba3da410962a43ed8e51c26b729208ec0ac2798d0"
+checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "crypto-mac"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
-dependencies = [
- "generic-array",
- "subtle",
-]
-
-[[package]]
-name = "crypto-mac"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff07008ec701e8028e2ceb8f83f0e4274ee62bd2dbdc4fefff2e9a91824081a"
-dependencies = [
- "generic-array",
- "subtle",
+ "typenum",
 ]
 
 [[package]]
 name = "digest"
-version = "0.9.0"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
 dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "digest"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b697d66081d42af4fba142d56918a3cb21dc8eb63372c6b85d14f44fb9c5979b"
-dependencies = [
- "block-buffer 0.10.0",
+ "block-buffer",
  "crypto-common",
- "generic-array",
  "subtle",
 ]
 
@@ -208,24 +147,20 @@ dependencies = [
 
 [[package]]
 name = "gost94"
-version = "0.9.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72c0d6a5d4cdfd9a2cab60cfad52bc683eb10ce13564a928d0a365a7f40e229c"
+checksum = "8526843c06d390a639d558d51e2b509bbbd9f337ad8036fb8c20519956c4b521"
 dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
- "opaque-debug",
+ "digest",
 ]
 
 [[package]]
 name = "groestl"
-version = "0.9.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2432787a9b8f0d58dca43fe2240399479b7582dc8afa2126dc7652b864029e47"
+checksum = "343cfc165f92a988fd60292f7a0bfde4352a5a0beff9fbec29251ca4e9676e4d"
 dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
- "opaque-debug",
+ "digest",
 ]
 
 [[package]]
@@ -254,21 +189,20 @@ checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
 
 [[package]]
 name = "hmac"
-version = "0.10.1"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "crypto-mac 0.10.1",
- "digest 0.9.0",
+ "digest",
 ]
 
 [[package]]
-name = "hmac"
-version = "0.12.0"
+name = "inout"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddca131f3e7f2ce2df364b57949a9d47915cfbd35e46cfee355ccebbf794d6a2"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
 dependencies = [
- "digest 0.10.1",
+ "generic-array",
 ]
 
 [[package]]
@@ -291,58 +225,36 @@ checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
 
 [[package]]
 name = "md-5"
-version = "0.9.1"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5a279bb9607f9f53c22d496eade00d138d1bdcccd07d74650387cf94942a15"
+checksum = "658646b21e0b72f7866c7038ab086d3d5e1cd6271f060fd37defb241949d0582"
 dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
- "opaque-debug",
+ "digest",
 ]
 
 [[package]]
 name = "md2"
-version = "0.9.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfd23bb613adebff88451d962b449f93e2ca5d97400021ad5895740778d95f78"
+checksum = "8848a2d533edb1bd24efdc5b292c0d69bb5648b08ec6ab244a66bcadede64203"
 dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
- "opaque-debug",
+ "digest",
 ]
 
 [[package]]
 name = "md4"
-version = "0.9.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd1a7931601ee6a560262a1dc9a8369949f5b7ae20b2bbf029c74fbd6d1b09e2"
+checksum = "93a5f5240a3fa1cb324a28cb42b1934750a093d7ad200ba052deecf4aff7104b"
 dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
- "opaque-debug",
-]
-
-[[package]]
-name = "opaque-debug"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
-
-[[package]]
-name = "password-hash"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54986aa4bfc9b98c6a5f40184223658d187159d7b3c6af33f2b2aa25ae1db0fa"
-dependencies = [
- "base64ct",
- "rand_core",
+ "digest",
 ]
 
 [[package]]
 name = "password-hash"
-version = "0.3.2"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d791538a6dcc1e7cb7fe6f6b58aca40e7f79403c45b2bc274008b5e647af1d8"
+checksum = "e029e94abc8fb0065241c308f1ac6bc8d20f450e8f7c5f0b25cd9b8d526ba294"
 dependencies = [
  "base64ct",
  "rand_core",
@@ -351,24 +263,14 @@ dependencies = [
 
 [[package]]
 name = "pbkdf2"
-version = "0.7.5"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf916dd32dd26297907890d99dc2740e33f6bd9073965af4ccff2967962f5508"
+checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
- "base64ct",
- "crypto-mac 0.10.1",
- "hmac 0.10.1",
- "password-hash 0.1.4",
- "sha2 0.9.8",
-]
-
-[[package]]
-name = "pbkdf2"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4628cc3cf953b82edcd3c1388c5715401420ce5524fedbab426bd5aba017434"
-dependencies = [
- "digest 0.10.1",
+ "digest",
+ "hmac",
+ "password-hash",
+ "sha2",
 ]
 
 [[package]]
@@ -423,48 +325,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "ripemd160"
-version = "0.9.1"
+name = "ripemd"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eca4ecc81b7f313189bf73ce724400a07da2a6dac19588b03c8bd76a2dcc251"
+checksum = "1facec54cb5e0dc08553501fa740091086d0259ad0067e0d4103448e4cb22ed3"
 dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
- "opaque-debug",
-]
-
-[[package]]
-name = "ripemd320"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ff9fb4227f99b2078691fbd1bf16edd94041f15b02a3c7b4a155d0074954191"
-dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
- "opaque-debug",
+ "digest",
 ]
 
 [[package]]
 name = "rustgenhash"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "argon2",
- "blake2 0.9.2",
- "digest 0.9.0",
+ "blake2",
+ "digest",
  "gost94",
  "groestl",
  "hex-literal",
  "md-5",
  "md2",
  "md4",
- "password-hash 0.3.2",
- "pbkdf2 0.7.5",
+ "password-hash",
+ "pbkdf2",
  "rand_core",
- "ripemd160",
- "ripemd320",
+ "ripemd",
  "scrypt",
  "sha-1",
- "sha2 0.9.8",
+ "sha2",
  "sha3",
  "shabal",
  "streebog",
@@ -476,95 +364,74 @@ dependencies = [
 
 [[package]]
 name = "salsa20"
-version = "0.9.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0fbb5f676da676c260ba276a8f43a8dc67cf02d1438423aeb1c677a7212686"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
 dependencies = [
  "cipher",
 ]
 
 [[package]]
 name = "scrypt"
-version = "0.8.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e73d6d7c6311ebdbd9184ad6c4447b2f36337e327bda107d3ba9e3c374f9d325"
+checksum = "9f9e24d2b632954ded8ab2ef9fea0a0c769ea56ea98bddbafbad22caeeadf45d"
 dependencies = [
- "hmac 0.12.0",
- "password-hash 0.3.2",
- "pbkdf2 0.10.0",
+ "hmac",
+ "password-hash",
+ "pbkdf2",
  "salsa20",
- "sha2 0.10.0",
+ "sha2",
 ]
 
 [[package]]
 name = "sha-1"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if",
- "cpufeatures",
- "digest 0.9.0",
- "opaque-debug",
-]
-
-[[package]]
-name = "sha2"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b69f9a4c9740d74c5baa3fd2e547f9525fa8088a8a958e0ca2409a514e33f5fa"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if",
- "cpufeatures",
- "digest 0.9.0",
- "opaque-debug",
-]
-
-[[package]]
-name = "sha2"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900d964dd36bb15bcf2f2b35694c072feab74969a54f2bbeec7a2d725d2bdcb6"
+checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.1",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
 name = "sha3"
-version = "0.9.1"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
+checksum = "881bf8156c87b6301fc5ca6b27f11eeb2761224c7081e69b409d5a1951a70c86"
 dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
+ "digest",
  "keccak",
- "opaque-debug",
 ]
 
 [[package]]
 name = "shabal"
-version = "0.3.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa63941ef67c979cfa571f32c93d30d21727c9c69310733ae9701fdd28243983"
+checksum = "990a6c7ff96ecc5664129bbf1f7b46a5a7c13f297d05af75e702f861cea6f08a"
 dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
- "opaque-debug",
+ "digest",
 ]
 
 [[package]]
 name = "streebog"
-version = "0.9.2"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9a21c1a3920381f27c666a81ad2481abc005900ac871a80b479e1869d54e753"
+checksum = "8d94bd56cd86f4e14c55c935baa313bfd37846284f6bb1f35fc71bc30e621241"
 dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
- "opaque-debug",
+ "digest",
 ]
 
 [[package]]
@@ -575,9 +442,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "structopt"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b9788f4202aa75c240ecc9c15c65185e6a39ccdeb0fd5d008b98825464c87c"
+checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
 dependencies = [
  "clap",
  "lazy_static",
@@ -625,13 +492,11 @@ dependencies = [
 
 [[package]]
 name = "tiger"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "443e531cbcf9de83258cfef70bcd56c91188de5819ebd4b19c85f589e0617005"
+checksum = "579abbce4ad73b04386dbeb34369c9873a8f9b749c7b99cbf479a2949ff715ed"
 dependencies = [
- "block-buffer 0.9.0",
- "byteorder",
- "digest 0.9.0",
+ "digest",
 ]
 
 [[package]]
@@ -678,13 +543,11 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "whirlpool"
-version = "0.9.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6b887d628151d048b725717536b20888cdf177c5673a5f5dfc48d700272664"
+checksum = "c72debd82fe039be0549a507b430075c64aa454882b90098fe97043f04110c21"
 dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
- "opaque-debug",
+ "digest",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,7 @@ repository = "https://github.com/vschwaberow/rustgenhash"
 readme = "README.md"
 keywords = ["cli", "crypto", "hashes", "rust"]
 edition = "2018"
-categories = [ "command-line-utilities", "cryptography"]
-
+categories = ["command-line-utilities", "cryptography"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
@@ -18,16 +17,20 @@ default = ["std"]
 std = []
 
 [dependencies]
+argon2 = "0.4.0"
 blake2 = "0.10.4"
 digest = { version = "0.10.3", features = ["std"] }
-md2 = "0.10.1"
-md4 = "0.10.1"
-md-5 = "0.10.1"
 gost94 = "0.10.2"
 groestl = "0.10.1"
+hex-literal = "0.3.3"
+md-5 = "0.10.1"
+md2 = "0.10.1"
+md4 = "0.10.1"
+password-hash = "0.4.1"
 pbkdf2 = { version = "0.11.0" }
 rand_core = { version = "0.6", features = ["std"] }
 ripemd = "0.1.1"
+scrypt = "0.10.0"
 sha-1 = "0.10.0"
 sha2 = "0.10.2"
 sha3 = "0.10.1"
@@ -35,9 +38,5 @@ shabal = "0.4.1"
 streebog = "0.10.1"
 structopt = "0.3.26"
 structopt-derive = "0.4.16"
-whirlpool = "0.10.1"
-hex-literal = "0.3.3"
-argon2 = "0.4.0"
-password-hash = "0.4.1"
-scrypt = "0.10.0"
 tiger = "0.2.1"
+whirlpool = "0.10.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustgenhash"
-version = "0.4.2"
+version = "0.5.0"
 license = "MIT/Apache-2.0"
 authors = ["Volker Schwaberow <volker@schwaberow.de>"]
 description = "A tool to generate hashes from the command line."
@@ -18,27 +18,26 @@ default = ["std"]
 std = []
 
 [dependencies]
-blake2 = "=0.9.2"
-digest = { version = "0.9.0", features = ["std"] }
-md2 = "0.9.0"
-md4 = "0.9.0"
-md-5 = "0.9.1"
-gost94 = "0.9.1"
-groestl = "0.9.0"
-pbkdf2 = { version = "0.7" }
+blake2 = "0.10.4"
+digest = { version = "0.10.3", features = ["std"] }
+md2 = "0.10.1"
+md4 = "0.10.1"
+md-5 = "0.10.1"
+gost94 = "0.10.2"
+groestl = "0.10.1"
+pbkdf2 = { version = "0.11.0" }
 rand_core = { version = "0.6", features = ["std"] }
-ripemd160 = "0.9.1"
-ripemd320 = "0.9.0"
-sha-1 = "0.9.8"
-sha2 = "0.9.8"
-sha3 = "0.9.1"
-shabal = "0.3.0"
-streebog = "0.9.2"
-structopt = "0.3.23"
+ripemd = "0.1.1"
+sha-1 = "0.10.0"
+sha2 = "0.10.2"
+sha3 = "0.10.1"
+shabal = "0.4.1"
+streebog = "0.10.1"
+structopt = "0.3.26"
 structopt-derive = "0.4.16"
-whirlpool = "0.9.0"
+whirlpool = "0.10.1"
 hex-literal = "0.3.3"
-argon2 = "0.3.2"
-password-hash = "0.3.2"
-scrypt = "0.8.1"
-tiger = "0.1.0"
+argon2 = "0.4.0"
+password-hash = "0.4.1"
+scrypt = "0.10.0"
+tiger = "0.2.1"

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Supported are:
 - BLAKE2b
 - BLAKE2s
 - GOST R 34.11-94
+- GOST 34.311-95 UA
 - Grøstl
 - MD2 hash
 - MD4 hash

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,26 +1,25 @@
-use blake2::{Blake2b, Blake2s};
+use crate::hash;
+use blake2::{Blake2b512, Blake2s256};
 use digest::Digest;
-use gost94::*;
-use groestl::*;
+use gost94::{Gost94Test, Gost94UA};
+use groestl::Groestl256;
 use md2::Md2;
 use md4::Md4;
 use md5::Md5;
-use ripemd160::Ripemd160;
-use ripemd320::*;
+use ripemd::{Ripemd160, Ripemd320};
 use sha1::Sha1;
 use sha2::{Sha224, Sha256, Sha384, Sha512};
 use sha3::{Sha3_224, Sha3_256, Sha3_384, Sha3_512};
 use shabal::{Shabal192, Shabal224, Shabal256, Shabal384, Shabal512};
 use std::io::BufRead;
 use std::process::exit;
-use streebog::*;
+use streebog::{Streebog256, Streebog512};
+use structopt::clap::{crate_authors, crate_name, crate_version};
 use structopt::StructOpt;
 use tiger::Tiger;
 use whirlpool::Whirlpool;
-use structopt::clap::{crate_authors, crate_name, crate_version};
-use crate::hash;
 
-const LONG_HELP_TXT: &str = r"A switch to provide the hash algorithm with which the provided string will be hashed. Supported are: argon2, blake2s, blake2b, gost94, groestl, md2, md4, md5, pbkdf2-sha256, pbkdf2-sha512, ripemd160, ripemd320, sha1, sha224, sha256, sha384, sha512, sha3-224, sha3-256, sha3-384, sha3-512, shabal192, shabal224, shabal256, shabal384, shabal512, streebog256, streebog512, tiger, whirlpool";
+const LONG_HELP_TXT: &str = r"A switch to provide the hash algorithm with which the provided string will be hashed. Supported are: argon2, blake2s, blake2b, gost94, gost94ua, groestl, md2, md4, md5, pbkdf2-sha256, pbkdf2-sha512, ripemd160, ripemd320, sha1, sha224, sha256, sha384, sha512, sha3-224, sha3-256, sha3-384, sha3-512, shabal192, shabal224, shabal256, shabal384, shabal512, streebog256, streebog512, tiger, whirlpool";
 
 #[derive(StructOpt, Debug)]
 #[structopt(
@@ -75,9 +74,10 @@ pub fn matching() {
             password,
         } => match &algorithm as &str {
             "argon2" => hash::hash_argon2(password),
-            "blake2b" => hash::hash_string(password, Blake2b::new()),
-            "blake2s" => hash::hash_string(password, Blake2s::new()),
+            "blake2b" => hash::hash_string(password, Blake2b512::new()),
+            "blake2s" => hash::hash_string(password, Blake2s256::new()),
             "gost94" => hash::hash_string(password, Gost94Test::new()),
+            "gost94ua" => hash::hash_string(password, Gost94UA::new()),
             "groestl" => hash::hash_string(password, Groestl256::new()),
             "md2" => hash::hash_string(password, Md2::new()),
             "md4" => hash::hash_string(password, Md4::new()),
@@ -110,9 +110,10 @@ pub fn matching() {
 
         Cmd::File { algorithm, input } => match &algorithm as &str {
             "argon2" => match_invalid_for_mode(),
-            "blake2b" => hash::hash_file(input, Blake2b::new()),
-            "blake2s" => hash::hash_file(input, Blake2s::new()),
+            "blake2b" => hash::hash_file(input, Blake2b512::new()),
+            "blake2s" => hash::hash_file(input, Blake2s256::new()),
             "gost94" => hash::hash_file(input, Gost94Test::new()),
+            "gost94ua" => hash::hash_file(input, Gost94UA::new()),
             "groestl" => hash::hash_file(input, Groestl256::new()),
             "md2" => hash::hash_file(input, Md2::new()),
             "md4" => hash::hash_file(input, Md4::new()),
@@ -149,9 +150,10 @@ pub fn matching() {
                 let password = lines.unwrap();
                 match &algorithm as &str {
                     "argon2" => hash::hash_argon2(password),
-                    "blake2b" => hash::hash_string(password, Blake2b::new()),
-                    "blake2s" => hash::hash_string(password, Blake2s::new()),
+                    "blake2b" => hash::hash_string(password, Blake2b512::new()),
+                    "blake2s" => hash::hash_string(password, Blake2s256::new()),
                     "gost94" => hash::hash_string(password, Gost94Test::new()),
+                    "gost94ua" => hash::hash_string(password, Gost94UA::new()),
                     "groestl" => hash::hash_string(password, Groestl256::new()),
                     "md2" => hash::hash_string(password, Md2::new()),
                     "md4" => hash::hash_string(password, Md4::new()),
@@ -187,6 +189,11 @@ pub fn matching() {
 }
 
 pub fn about() {
-    println!("{} v{} by {}", crate_name!(), crate_version!(), crate_authors!());
+    println!(
+        "{} v{} by {}",
+        crate_name!(),
+        crate_version!(),
+        crate_authors!()
+    );
     println!();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,5 @@
-
-
-mod hash;
 mod command;
+mod hash;
 
 fn main() {
     command::about();

--- a/tests/hashes.rs
+++ b/tests/hashes.rs
@@ -1,12 +1,11 @@
-use blake2::{Blake2b, Blake2s};
+use blake2::{Blake2b512, Blake2s256};
 use gost94::Gost94Test;
 use groestl::Groestl256;
 use hex_literal::hex;
 use md2::Md2;
 use md4::Md4;
 use md5::Md5;
-use ripemd160::Ripemd160;
-use ripemd320::Ripemd320;
+use ripemd::{Ripemd160, Ripemd320};
 use sha1::{Digest, Sha1};
 use sha2::{Sha224, Sha256, Sha384, Sha512};
 use sha3::{Sha3_224, Sha3_256, Sha3_384, Sha3_512};
@@ -18,7 +17,7 @@ const PHRASE: &str = "Jeder wackere Bayer vertilgt bequem zwo Pfund Kalbshaxen."
 
 #[test]
 fn lib_blake2b_hash() {
-    let mut hasher = Blake2b::new();
+    let mut hasher = Blake2b512::new();
     hasher.update(PHRASE.as_bytes());
     let result = hasher.finalize();
     assert_eq!(result[..], hex!("95b7ecb0d7de59820205a0a94fe3ca5ee36fd296b1a9ecaa4e01634aed9fa9505d70182c12f900b9dd95f1d5c04fe57dbc5b1e48acdf3a8bae2996f5d8f4578a"));
@@ -26,7 +25,7 @@ fn lib_blake2b_hash() {
 
 #[test]
 fn lib_blake2s_hash() {
-    let mut hasher = Blake2s::new();
+    let mut hasher = Blake2s256::new();
     hasher.update(PHRASE.as_bytes());
     let result = hasher.finalize();
     assert_eq!(

--- a/tests/hashes.rs
+++ b/tests/hashes.rs
@@ -1,5 +1,5 @@
 use blake2::{Blake2b512, Blake2s256};
-use gost94::Gost94Test;
+use gost94::{Gost94Test, Gost94UA};
 use groestl::Groestl256;
 use hex_literal::hex;
 use md2::Md2;
@@ -42,6 +42,17 @@ fn lib_gost94_hash() {
     assert_eq!(
         result[..],
         hex!("1845acc06577ead1f5b671e7e452fc6064e90ab1bbb536df36a91327e40e1872")
+    );
+}
+
+#[test]
+fn lib_gost94ua_hash() {
+    let mut hasher = Gost94UA::new();
+    hasher.update(PHRASE.as_bytes());
+    let result = hasher.finalize();
+    assert_eq!(
+        result[..],
+        hex!("3a8ce1ee676fa5b0c942c0426309b165376e23cc7d826f31944cdc827aaf674a")
     );
 }
 

--- a/tests/hashes.rs
+++ b/tests/hashes.rs
@@ -1,21 +1,20 @@
 use blake2::{Blake2b, Blake2s};
 use gost94::Gost94Test;
-use hex_literal::hex;
-use sha1::{Sha1, Digest};
 use groestl::Groestl256;
+use hex_literal::hex;
 use md2::Md2;
 use md4::Md4;
 use md5::Md5;
 use ripemd160::Ripemd160;
 use ripemd320::Ripemd320;
+use sha1::{Digest, Sha1};
 use sha2::{Sha224, Sha256, Sha384, Sha512};
 use sha3::{Sha3_224, Sha3_256, Sha3_384, Sha3_512};
 use shabal::{Shabal192, Shabal224, Shabal256, Shabal384, Shabal512};
 use streebog::{Streebog256, Streebog512};
 use whirlpool::Whirlpool;
 
-
-const PHRASE:&str = "Jeder wackere Bayer vertilgt bequem zwo Pfund Kalbshaxen.";
+const PHRASE: &str = "Jeder wackere Bayer vertilgt bequem zwo Pfund Kalbshaxen.";
 
 #[test]
 fn lib_blake2b_hash() {
@@ -30,7 +29,10 @@ fn lib_blake2s_hash() {
     let mut hasher = Blake2s::new();
     hasher.update(PHRASE.as_bytes());
     let result = hasher.finalize();
-    assert_eq!(result[..], hex!("dbfd3f2c835adcc9fc955d812384bb3bf569de0b9613ffca0e723254c05cf497"));
+    assert_eq!(
+        result[..],
+        hex!("dbfd3f2c835adcc9fc955d812384bb3bf569de0b9613ffca0e723254c05cf497")
+    );
 }
 
 #[test]
@@ -38,7 +40,10 @@ fn lib_gost94_hash() {
     let mut hasher = Gost94Test::new();
     hasher.update(PHRASE.as_bytes());
     let result = hasher.finalize();
-    assert_eq!(result[..], hex!("1845acc06577ead1f5b671e7e452fc6064e90ab1bbb536df36a91327e40e1872"));
+    assert_eq!(
+        result[..],
+        hex!("1845acc06577ead1f5b671e7e452fc6064e90ab1bbb536df36a91327e40e1872")
+    );
 }
 
 #[test]
@@ -46,7 +51,10 @@ fn lib_groestl_hash() {
     let mut hasher = Groestl256::new();
     hasher.update(PHRASE.as_bytes());
     let result = hasher.finalize();
-    assert_eq!(result[..], hex!("f65cae36b7a0cb51e8ee732f4090ffacaa8f910a793596046073b8457bc4a356"));
+    assert_eq!(
+        result[..],
+        hex!("f65cae36b7a0cb51e8ee732f4090ffacaa8f910a793596046073b8457bc4a356")
+    );
 }
 
 #[test]
@@ -86,7 +94,10 @@ fn lib_ripemd320_hash() {
     let mut hasher = Ripemd320::new();
     hasher.update(PHRASE.as_bytes());
     let result = hasher.finalize();
-    assert_eq!(result[..], hex!("e34757b3c51470ec4a47a06a39ffbe85587f41f9711facc25bdcf5d74ebf44e59743ca07bd70ab5e"));
+    assert_eq!(
+        result[..],
+        hex!("e34757b3c51470ec4a47a06a39ffbe85587f41f9711facc25bdcf5d74ebf44e59743ca07bd70ab5e")
+    );
 }
 
 #[test]
@@ -102,12 +113,18 @@ fn lib_sha2_hash() {
     let mut hasher = Sha224::new();
     hasher.update(PHRASE.as_bytes());
     let result = hasher.finalize();
-    assert_eq!(result[..], hex!("89f96bccbae0d803667fee6afdd18e2c7df1c93121a24d5878d92afe"));
+    assert_eq!(
+        result[..],
+        hex!("89f96bccbae0d803667fee6afdd18e2c7df1c93121a24d5878d92afe")
+    );
 
     let mut hasher = Sha256::new();
     hasher.update(PHRASE.as_bytes());
     let result = hasher.finalize();
-    assert_eq!(result[..], hex!("4c3478a95c7b19f747de6d9a0ac49517e37a1312768dd64093626290e5b3ed79"));
+    assert_eq!(
+        result[..],
+        hex!("4c3478a95c7b19f747de6d9a0ac49517e37a1312768dd64093626290e5b3ed79")
+    );
 
     let mut hasher = Sha384::new();
     hasher.update(PHRASE.as_bytes());
@@ -125,12 +142,18 @@ fn lib_sha3_hash() {
     let mut hasher = Sha3_224::new();
     hasher.update(PHRASE.as_bytes());
     let result = hasher.finalize();
-    assert_eq!(result[..], hex!("a3d42c4ca398f6e3deb5f9829db812ec5683a5e908a2a6b5aca5bc2f"));
+    assert_eq!(
+        result[..],
+        hex!("a3d42c4ca398f6e3deb5f9829db812ec5683a5e908a2a6b5aca5bc2f")
+    );
 
     let mut hasher = Sha3_256::new();
     hasher.update(PHRASE.as_bytes());
     let result = hasher.finalize();
-    assert_eq!(result[..], hex!("7f3b18201d8a0243af7f0190024211066a91c9579889fc80df52e7981de814ef"));
+    assert_eq!(
+        result[..],
+        hex!("7f3b18201d8a0243af7f0190024211066a91c9579889fc80df52e7981de814ef")
+    );
 
     let mut hasher = Sha3_384::new();
     hasher.update(PHRASE.as_bytes());
@@ -148,17 +171,26 @@ fn lib_shabal_hash() {
     let mut hasher = Shabal192::new();
     hasher.update(PHRASE.as_bytes());
     let result = hasher.finalize();
-    assert_eq!(result[..], hex!("2e74a8bae598b18ad03179eed4ddf334f0c8d7bf2062141c"));
+    assert_eq!(
+        result[..],
+        hex!("2e74a8bae598b18ad03179eed4ddf334f0c8d7bf2062141c")
+    );
 
     let mut hasher = Shabal224::new();
     hasher.update(PHRASE.as_bytes());
     let result = hasher.finalize();
-    assert_eq!(result[..], hex!("5726195b421e6694cd27069e43b0b5fdf470e100680fc0a176e98602"));
+    assert_eq!(
+        result[..],
+        hex!("5726195b421e6694cd27069e43b0b5fdf470e100680fc0a176e98602")
+    );
 
     let mut hasher = Shabal256::new();
     hasher.update(PHRASE.as_bytes());
     let result = hasher.finalize();
-    assert_eq!(result[..], hex!("2416fcb3074316430af2ee338aba58e1d965f5436fa074eb5a5f22b47ee0a32f"));
+    assert_eq!(
+        result[..],
+        hex!("2416fcb3074316430af2ee338aba58e1d965f5436fa074eb5a5f22b47ee0a32f")
+    );
 
     let mut hasher = Shabal384::new();
     hasher.update(PHRASE.as_bytes());
@@ -176,7 +208,10 @@ fn lib_streebog_hash() {
     let mut hasher = Streebog256::new();
     hasher.update(PHRASE.as_bytes());
     let result = hasher.finalize();
-    assert_eq!(result[..], hex!("51526ca01cc97f72fde98a9e45bbd3e4ba54a478ab9a8db550354be5295f9f00"));
+    assert_eq!(
+        result[..],
+        hex!("51526ca01cc97f72fde98a9e45bbd3e4ba54a478ab9a8db550354be5295f9f00")
+    );
 
     let mut hasher = Streebog512::new();
     hasher.update(PHRASE.as_bytes());


### PR DESCRIPTION

- Bump dependencies
- add [gost94ua](https://docs.rs/gost94/0.10.2/gost94/type.Gost94UA.html) algorithm
- replace deprecated `ripemd160/320` by `ripemd`
- run `cargo fmt`