### PR TITLE
Move to clap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 3
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "argon2"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -32,6 +23,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64ct"
@@ -81,17 +78,50 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "3.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "d2dbdf4bdacb33466e854ce889eee8dfd5729abf7ccd7664d0a2d60cd384440b"
 dependencies = [
- "ansi_term",
  "atty",
  "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "indexmap",
+ "lazy_static",
  "strsim",
+ "termcolor",
  "textwrap",
- "unicode-width",
- "vec_map",
+]
+
+[[package]]
+name = "clap_complete"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da92e6facd8d73c22745a5d3cbb59bdf8e46e3235c923e516527d8e81eec14a4"
+dependencies = [
+ "clap",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25320346e922cffe59c0bbc5410c8d8784509efb321488971081313cb1e1a33c"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a37c35f1112dad5e6e0b1adaff798507497a18fceeb30cceb3bae7d1427b9213"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -164,13 +194,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "heck"
-version = "0.3.3"
+name = "hashbrown"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -194,6 +227,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6012d540c5baa3589337a98ce73408de9b5a25ec9fc2c6fd6be8f0d39e0ca5a"
+dependencies = [
+ "autocfg",
+ "hashbrown",
 ]
 
 [[package]]
@@ -251,6 +294,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21326818e99cfe6ce1e524c2a805c189a99b5ae555a35d19f9a284b427d86afa"
+
+[[package]]
 name = "password-hash"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -299,18 +348,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.34"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f84e92c0f7c9d58328b85a78557813e4bd845130db68d7184635344399423b1"
+checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.10"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
+checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
 dependencies = [
  "proc-macro2",
 ]
@@ -335,10 +384,12 @@ dependencies = [
 
 [[package]]
 name = "rustgenhash"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "argon2",
  "blake2",
+ "clap",
+ "clap_complete",
  "digest",
  "gost94",
  "groestl",
@@ -356,8 +407,6 @@ dependencies = [
  "sha3",
  "shabal",
  "streebog",
- "structopt",
- "structopt-derive",
  "tiger",
  "whirlpool",
 ]
@@ -436,33 +485,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "subtle"
@@ -472,23 +497,29 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.82"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8daf5dd0bb60cbd4137b1b587d2fc0ae729bc07cf01cd70b36a1ed5ade3b9d59"
+checksum = "fbaf6116ab8924f39d52792136fb74fd60a80194cf1b1c6ffa6453eef1c3f942"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "tiger"
@@ -506,28 +537,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.8.0"
+name = "unicode-ident"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+checksum = "d22af068fba1eb5edcb4aea19d382b2a3deb4c8f9d475c589b6ada9e0fd493ee"
 
 [[package]]
 name = "version_check"
@@ -565,6 +578,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustgenhash"
-version = "0.5.0"
+version = "0.5.1"
 license = "MIT/Apache-2.0"
 authors = ["Volker Schwaberow <volker@schwaberow.de>"]
 description = "A tool to generate hashes from the command line."
@@ -19,6 +19,8 @@ std = []
 [dependencies]
 argon2 = "0.4.0"
 blake2 = "0.10.4"
+clap = { version = "3.1", features = ["derive", "cargo"] }
+clap_complete = "3.1"
 digest = { version = "0.10.3", features = ["std"] }
 gost94 = "0.10.2"
 groestl = "0.10.1"
@@ -36,7 +38,5 @@ sha2 = "0.10.2"
 sha3 = "0.10.1"
 shabal = "0.4.1"
 streebog = "0.10.1"
-structopt = "0.3.26"
-structopt-derive = "0.4.16"
 tiger = "0.2.1"
 whirlpool = "0.10.1"

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Supported are:
 - PBKDF2-SHA512 (Only String and stdio)
 - RipeMD160
 - RipeMD320
+- Scrypt (Only String and stdio)
 - SHA-1 hash
 - SHA2-224 hash
 - SHA2-256 hash
@@ -84,3 +85,12 @@ Supported are:
 - Streebog512
 - Tiger (Only String and stdio)
 - Whirlpool
+
+
+Generate shell completions:
+
+```bash
+rustgenhash generate-completions <SHELL> > some_path
+```
+
+Supported shells: bash, elvish, fish, power-shell, zsh

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,93 @@
+use clap::{ArgEnum, Parser, Subcommand};
+
+#[derive(Parser, Debug)]
+#[clap(
+    name = "rustgenhash",
+    about = "CLI utility to generate hashes for files and strings."
+)]
+pub struct Cmd {
+    #[clap(subcommand)]
+    pub mode: Mode,
+}
+
+#[derive(Debug, ArgEnum, Clone)]
+pub enum Algorithm {
+    Argon2,
+    Blake2b,
+    Blake2s,
+    Gost94,
+    Gost94ua,
+    Groestl,
+    Md2,
+    Md4,
+    Md5,
+    Pbkdf2Sha256,
+    Pbkdf2Sha512,
+    Ripemd160,
+    Ripemd320,
+    Scrypt,
+    Sha1,
+    Sha224,
+    Sha256,
+    Sha384,
+    Sha512,
+    Sha3_224,
+    Sha3_256,
+    Sha3_384,
+    Sha3_512,
+    Shabal192,
+    Shabal224,
+    Shabal256,
+    Shabal384,
+    Shabal512,
+    Streebog256,
+    Streebog512,
+    Tiger,
+    Whirlpool,
+}
+
+#[derive(Debug, ArgEnum, Clone)]
+pub enum Shell {
+    Bash,
+    Elvish,
+    Fish,
+    PowerShell,
+    Zsh,
+}
+
+impl From<Shell> for clap_complete::Shell {
+    fn from(shell: Shell) -> Self {
+        use Shell::*;
+        match shell {
+            Bash => Self::Bash,
+            Elvish => Self::Elvish,
+            Fish => Self::Fish,
+            PowerShell => Self::PowerShell,
+            Zsh => Self::Zsh,
+        }
+    }
+}
+
+#[derive(Debug, Subcommand, Clone)]
+pub enum Mode {
+    File {
+        #[clap(short, arg_enum, required = true)]
+        algorithm: Algorithm,
+        #[clap(name = "FILENAME", required = true)]
+        input: String,
+    },
+    String {
+        #[clap(short, arg_enum, required = true)]
+        algorithm: Algorithm,
+        #[clap(name = "PASSWORD", required = true)]
+        password: String,
+    },
+    Stdio {
+        #[clap(short, arg_enum, required = true)]
+        algorithm: Algorithm,
+    },
+    GenerateCompletions {
+        #[clap(arg_enum, required = true)]
+        shell: Shell,
+    },
+}

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,5 +1,8 @@
+use crate::cli::{Algorithm, Cmd, Mode};
 use crate::hash;
 use blake2::{Blake2b512, Blake2s256};
+use clap::{crate_authors, crate_name, crate_version};
+use clap::{CommandFactory, Parser};
 use digest::Digest;
 use gost94::{Gost94Test, Gost94UA};
 use groestl::Groestl256;
@@ -11,189 +14,115 @@ use sha1::Sha1;
 use sha2::{Sha224, Sha256, Sha384, Sha512};
 use sha3::{Sha3_224, Sha3_256, Sha3_384, Sha3_512};
 use shabal::{Shabal192, Shabal224, Shabal256, Shabal384, Shabal512};
-use std::io::BufRead;
+use std::io::{self, BufRead};
 use std::process::exit;
 use streebog::{Streebog256, Streebog512};
-use structopt::clap::{crate_authors, crate_name, crate_version};
-use structopt::StructOpt;
 use tiger::Tiger;
 use whirlpool::Whirlpool;
-
-const LONG_HELP_TXT: &str = r"A switch to provide the hash algorithm with which the provided string will be hashed. Supported are: argon2, blake2s, blake2b, gost94, gost94ua, groestl, md2, md4, md5, pbkdf2-sha256, pbkdf2-sha512, ripemd160, ripemd320, sha1, sha224, sha256, sha384, sha512, sha3-224, sha3-256, sha3-384, sha3-512, shabal192, shabal224, shabal256, shabal384, shabal512, streebog256, streebog512, tiger, whirlpool";
-
-#[derive(StructOpt, Debug)]
-#[structopt(
-    name = "rustgenhash",
-    about = "CLI utility to generate hashes for files and strings."
-)]
-pub enum Cmd {
-    File {
-        #[structopt(
-            short,
-            required = true,
-            long_help = LONG_HELP_TXT,
-        )]
-        algorithm: String,
-        #[structopt(name = "FILENAME", required = true)]
-        input: String,
-    },
-    String {
-        #[structopt(
-            short,
-            required = true,
-            long_help = LONG_HELP_TXT,
-        )]
-        algorithm: String,
-        #[structopt(name = "PASSWORD", required = true)]
-        password: String,
-    },
-    Stdio {
-        #[structopt(
-        short,
-        required = true,
-        long_help = LONG_HELP_TXT,
-        )]
-        algorithm: String,
-    },
-}
-
-fn match_invalid() {
-    println!("You need to select a valid algorithm.");
-    exit(1);
-}
 
 fn match_invalid_for_mode() {
     println!("This algorithm is not supported in this mode. You need to select a valid algorithm for this mode.");
     exit(1);
 }
 
+fn hash_string(algorithm: Algorithm, password: &str) {
+    match algorithm {
+        Algorithm::Argon2 => hash::hash_argon2(password),
+        Algorithm::Blake2b => hash::hash_string(password, Blake2b512::new()),
+        Algorithm::Blake2s => hash::hash_string(password, Blake2s256::new()),
+        Algorithm::Gost94 => hash::hash_string(password, Gost94Test::new()),
+        Algorithm::Gost94ua => hash::hash_string(password, Gost94UA::new()),
+        Algorithm::Groestl => hash::hash_string(password, Groestl256::new()),
+        Algorithm::Md2 => hash::hash_string(password, Md2::new()),
+        Algorithm::Md4 => hash::hash_string(password, Md4::new()),
+        Algorithm::Md5 => hash::hash_string(password, Md5::new()),
+        Algorithm::Pbkdf2Sha256 => hash::hash_pbkdf2(password, "pbkdf2-sha256"),
+        Algorithm::Pbkdf2Sha512 => hash::hash_pbkdf2(password, "pbkdf2-sha512"),
+        Algorithm::Ripemd160 => hash::hash_string(password, Ripemd160::new()),
+        Algorithm::Ripemd320 => hash::hash_string(password, Ripemd320::new()),
+        Algorithm::Scrypt => hash::hash_scrypt(password),
+        Algorithm::Sha1 => hash::hash_string(password, Sha1::new()),
+        Algorithm::Sha224 => hash::hash_string(password, Sha224::new()),
+        Algorithm::Sha256 => hash::hash_string(password, Sha256::new()),
+        Algorithm::Sha384 => hash::hash_string(password, Sha384::new()),
+        Algorithm::Sha512 => hash::hash_string(password, Sha512::new()),
+        Algorithm::Sha3_224 => hash::hash_string(password, Sha3_224::new()),
+        Algorithm::Sha3_256 => hash::hash_string(password, Sha3_256::new()),
+        Algorithm::Sha3_384 => hash::hash_string(password, Sha3_384::new()),
+        Algorithm::Sha3_512 => hash::hash_string(password, Sha3_512::new()),
+        Algorithm::Shabal192 => hash::hash_string(password, Shabal192::new()),
+        Algorithm::Shabal224 => hash::hash_string(password, Shabal224::new()),
+        Algorithm::Shabal256 => hash::hash_string(password, Shabal256::new()),
+        Algorithm::Shabal384 => hash::hash_string(password, Shabal384::new()),
+        Algorithm::Shabal512 => hash::hash_string(password, Shabal512::new()),
+        Algorithm::Streebog256 => hash::hash_string(password, Streebog256::new()),
+        Algorithm::Streebog512 => hash::hash_string(password, Streebog512::new()),
+        Algorithm::Tiger => hash::hash_string(password, Tiger::new()),
+        Algorithm::Whirlpool => hash::hash_string(password, Whirlpool::new()),
+    }
+}
+
 pub fn matching() {
-    match Cmd::from_args() {
-        Cmd::String {
+    let cmd = Cmd::parse();
+    match cmd.mode {
+        Mode::GenerateCompletions { shell } => {
+            let shell: clap_complete::Shell = shell.into();
+            clap_complete::generate(shell, &mut Cmd::command(), crate_name!(), &mut io::stdout());
+        }
+        Mode::String {
             algorithm,
             password,
-        } => match &algorithm as &str {
-            "argon2" => hash::hash_argon2(password),
-            "blake2b" => hash::hash_string(password, Blake2b512::new()),
-            "blake2s" => hash::hash_string(password, Blake2s256::new()),
-            "gost94" => hash::hash_string(password, Gost94Test::new()),
-            "gost94ua" => hash::hash_string(password, Gost94UA::new()),
-            "groestl" => hash::hash_string(password, Groestl256::new()),
-            "md2" => hash::hash_string(password, Md2::new()),
-            "md4" => hash::hash_string(password, Md4::new()),
-            "md5" => hash::hash_string(password, Md5::new()),
-            "pbkdf2-sha256" => hash::hash_pbkdf2(password, "pbkdf2-sha256"),
-            "pbkdf2-sha512" => hash::hash_pbkdf2(password, "pbkdf2-sha512"),
-            "ripemd160" => hash::hash_string(password, Ripemd160::new()),
-            "ripemd320" => hash::hash_string(password, Ripemd320::new()),
-            "scrypt" => hash::hash_scrypt(password),
-            "sha1" => hash::hash_string(password, Sha1::new()),
-            "sha224" => hash::hash_string(password, Sha224::new()),
-            "sha256" => hash::hash_string(password, Sha256::new()),
-            "sha384" => hash::hash_string(password, Sha384::new()),
-            "sha512" => hash::hash_string(password, Sha512::new()),
-            "sha3-224" => hash::hash_string(password, Sha3_224::new()),
-            "sha3-256" => hash::hash_string(password, Sha3_256::new()),
-            "sha3-384" => hash::hash_string(password, Sha3_384::new()),
-            "sha3-512" => hash::hash_string(password, Sha3_512::new()),
-            "shabal192" => hash::hash_string(password, Shabal192::new()),
-            "shabal224" => hash::hash_string(password, Shabal224::new()),
-            "shabal256" => hash::hash_string(password, Shabal256::new()),
-            "shabal384" => hash::hash_string(password, Shabal384::new()),
-            "shabal512" => hash::hash_string(password, Shabal512::new()),
-            "streebog256" => hash::hash_string(password, Streebog256::new()),
-            "streebog512" => hash::hash_string(password, Streebog512::new()),
-            "tiger" => hash::hash_string(password, Tiger::new()),
-            "whirlpool" => hash::hash_string(password, Whirlpool::new()),
-            _ => match_invalid(),
-        },
-
-        Cmd::File { algorithm, input } => match &algorithm as &str {
-            "argon2" => match_invalid_for_mode(),
-            "blake2b" => hash::hash_file(input, Blake2b512::new()),
-            "blake2s" => hash::hash_file(input, Blake2s256::new()),
-            "gost94" => hash::hash_file(input, Gost94Test::new()),
-            "gost94ua" => hash::hash_file(input, Gost94UA::new()),
-            "groestl" => hash::hash_file(input, Groestl256::new()),
-            "md2" => hash::hash_file(input, Md2::new()),
-            "md4" => hash::hash_file(input, Md4::new()),
-            "md5" => hash::hash_file(input, Md5::new()),
-            "pbkdf2" => match_invalid_for_mode(),
-            "pbkdf2-sha256" => match_invalid_for_mode(),
-            "pbkdf2-sha512" => match_invalid_for_mode(),
-            "ripemd160" => hash::hash_file(input, Ripemd160::new()),
-            "ripemd320" => hash::hash_file(input, Ripemd320::new()),
-            "scrypt" => match_invalid_for_mode(),
-            "sha1" => hash::hash_file(input, Sha1::new()),
-            "sha224" => hash::hash_file(input, Sha224::new()),
-            "sha256" => hash::hash_file(input, Sha256::new()),
-            "sha384" => hash::hash_file(input, Sha384::new()),
-            "sha512" => hash::hash_file(input, Sha512::new()),
-            "sha3-224" => hash::hash_file(input, Sha3_224::new()),
-            "sha3-256" => hash::hash_file(input, Sha3_256::new()),
-            "sha3-384" => hash::hash_file(input, Sha3_384::new()),
-            "sha3-512" => hash::hash_file(input, Sha3_512::new()),
-            "shabal192" => hash::hash_file(input, Shabal192::new()),
-            "shabal224" => hash::hash_file(input, Shabal224::new()),
-            "shabal256" => hash::hash_file(input, Shabal256::new()),
-            "shabal384" => hash::hash_file(input, Shabal384::new()),
-            "shabal512" => hash::hash_file(input, Shabal512::new()),
-            "streebog256" => hash::hash_file(input, Streebog256::new()),
-            "streebog512" => hash::hash_file(input, Streebog512::new()),
-            "tiger" => match_invalid_for_mode(),
-            "whirlpool" => hash::hash_file(input, Whirlpool::new()),
-            _ => match_invalid(),
-        },
-        Cmd::Stdio { algorithm } => {
+        } => hash_string(algorithm, &password),
+        Mode::Stdio { algorithm } => {
             let stdin = std::io::stdin();
             for lines in stdin.lock().lines() {
                 let password = lines.unwrap();
-                match &algorithm as &str {
-                    "argon2" => hash::hash_argon2(password),
-                    "blake2b" => hash::hash_string(password, Blake2b512::new()),
-                    "blake2s" => hash::hash_string(password, Blake2s256::new()),
-                    "gost94" => hash::hash_string(password, Gost94Test::new()),
-                    "gost94ua" => hash::hash_string(password, Gost94UA::new()),
-                    "groestl" => hash::hash_string(password, Groestl256::new()),
-                    "md2" => hash::hash_string(password, Md2::new()),
-                    "md4" => hash::hash_string(password, Md4::new()),
-                    "md5" => hash::hash_string(password, Md5::new()),
-                    "pbkdf2-sha256" => hash::hash_pbkdf2(password, "pbkdf2-sha256"),
-                    "pbkdf2-sha512" => hash::hash_pbkdf2(password, "pbkdf2-sha512"),
-                    "ripemd160" => hash::hash_string(password, Ripemd160::new()),
-                    "ripemd320" => hash::hash_string(password, Ripemd320::new()),
-                    "scrypt" => hash::hash_scrypt(password),
-                    "sha1" => hash::hash_string(password, Sha1::new()),
-                    "sha224" => hash::hash_string(password, Sha224::new()),
-                    "sha256" => hash::hash_string(password, Sha256::new()),
-                    "sha384" => hash::hash_string(password, Sha384::new()),
-                    "sha512" => hash::hash_string(password, Sha512::new()),
-                    "sha3-224" => hash::hash_string(password, Sha3_224::new()),
-                    "sha3-256" => hash::hash_string(password, Sha3_256::new()),
-                    "sha3-384" => hash::hash_string(password, Sha3_384::new()),
-                    "sha3-512" => hash::hash_string(password, Sha3_512::new()),
-                    "shabal192" => hash::hash_string(password, Shabal192::new()),
-                    "shabal224" => hash::hash_string(password, Shabal224::new()),
-                    "shabal256" => hash::hash_string(password, Shabal256::new()),
-                    "shabal384" => hash::hash_string(password, Shabal384::new()),
-                    "shabal512" => hash::hash_string(password, Shabal512::new()),
-                    "streebog256" => hash::hash_string(password, Streebog256::new()),
-                    "streebog512" => hash::hash_string(password, Streebog512::new()),
-                    "tiger" => hash::hash_string(password, Tiger::new()),
-                    "whirlpool" => hash::hash_string(password, Whirlpool::new()),
-                    _ => match_invalid(),
-                }
+                hash_string(algorithm.clone(), &password);
             }
         }
+        Mode::File { algorithm, input } => match algorithm {
+            Algorithm::Argon2 => match_invalid_for_mode(),
+            Algorithm::Blake2b => hash::hash_file(input, Blake2b512::new()),
+            Algorithm::Blake2s => hash::hash_file(input, Blake2s256::new()),
+            Algorithm::Gost94 => hash::hash_file(input, Gost94Test::new()),
+            Algorithm::Gost94ua => hash::hash_file(input, Gost94UA::new()),
+            Algorithm::Groestl => hash::hash_file(input, Groestl256::new()),
+            Algorithm::Md2 => hash::hash_file(input, Md2::new()),
+            Algorithm::Md4 => hash::hash_file(input, Md4::new()),
+            Algorithm::Md5 => hash::hash_file(input, Md5::new()),
+            Algorithm::Pbkdf2Sha256 => match_invalid_for_mode(),
+            Algorithm::Pbkdf2Sha512 => match_invalid_for_mode(),
+            Algorithm::Ripemd160 => hash::hash_file(input, Ripemd160::new()),
+            Algorithm::Ripemd320 => hash::hash_file(input, Ripemd320::new()),
+            Algorithm::Scrypt => match_invalid_for_mode(),
+            Algorithm::Sha1 => hash::hash_file(input, Sha1::new()),
+            Algorithm::Sha224 => hash::hash_file(input, Sha224::new()),
+            Algorithm::Sha256 => hash::hash_file(input, Sha256::new()),
+            Algorithm::Sha384 => hash::hash_file(input, Sha384::new()),
+            Algorithm::Sha512 => hash::hash_file(input, Sha512::new()),
+            Algorithm::Sha3_224 => hash::hash_file(input, Sha3_224::new()),
+            Algorithm::Sha3_256 => hash::hash_file(input, Sha3_256::new()),
+            Algorithm::Sha3_384 => hash::hash_file(input, Sha3_384::new()),
+            Algorithm::Sha3_512 => hash::hash_file(input, Sha3_512::new()),
+            Algorithm::Shabal192 => hash::hash_file(input, Shabal192::new()),
+            Algorithm::Shabal224 => hash::hash_file(input, Shabal224::new()),
+            Algorithm::Shabal256 => hash::hash_file(input, Shabal256::new()),
+            Algorithm::Shabal384 => hash::hash_file(input, Shabal384::new()),
+            Algorithm::Shabal512 => hash::hash_file(input, Shabal512::new()),
+            Algorithm::Streebog256 => hash::hash_file(input, Streebog256::new()),
+            Algorithm::Streebog512 => hash::hash_file(input, Streebog512::new()),
+            Algorithm::Tiger => match_invalid_for_mode(),
+            Algorithm::Whirlpool => hash::hash_file(input, Whirlpool::new()),
+        },
     }
 }
 
 pub fn about() {
-    println!(
+    eprintln!(
         "{} v{} by {}",
         crate_name!(),
         crate_version!(),
         crate_authors!()
     );
-    println!();
+    eprintln!();
 }

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -48,7 +48,7 @@ where
     }
 }
 
-pub fn hash_scrypt(password: String) {
+pub fn hash_scrypt(password: &str) {
     let salt = ScSaltString::generate(&mut OsRng);
     let password_hash = Scrypt
         .hash_password(password.as_bytes(), &salt)
@@ -57,7 +57,7 @@ pub fn hash_scrypt(password: String) {
     println!("{} {}", password_hash, password);
 }
 
-pub fn hash_argon2(password: String) {
+pub fn hash_argon2(password: &str) {
     let salt = SaltString::generate(&mut OsRng);
     let argon2 = Argon2::default();
     let password_hash = argon2
@@ -67,7 +67,7 @@ pub fn hash_argon2(password: String) {
     println!("{} {}", password_hash, password);
 }
 
-pub fn hash_pbkdf2(password: String, pb_scheme: &str) {
+pub fn hash_pbkdf2(password: &str, pb_scheme: &str) {
     let algorithm = PbIdent::new(pb_scheme).unwrap();
 
     let salt = PbSaltString::generate(&mut OsRng);
@@ -91,7 +91,7 @@ pub fn hash_pbkdf2(password: String, pb_scheme: &str) {
     println!("{} {}", password_hash, password);
 }
 
-pub fn hash_string<D>(password: String, mut hasher: D)
+pub fn hash_string<D>(password: &str, mut hasher: D)
 where
     D: Digest,
     D::OutputSize: Add,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod cli;
 mod command;
 mod hash;
 


### PR DESCRIPTION
- Move from `structopt` (now in maintenance mode) to `clap`
- Add `generate-completions` mode using `clap_complete` crate
- Add `Algorithm` enum. Now clap produces nice suggestions:
![image](https://user-images.githubusercontent.com/26857105/170884552-8685c9da-adf9-4aa8-a70a-a5185587acdc.png)

- `command::about` uses `eprintln` for ability to redirect stdout to file without this header