### PR TITLE
Bug: URL with proper protocol fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ rgh analyze -a <algorithm> <hash>
 Scheme for generating a [HHHash](https://www.foo.be/2023/07/HTTP-Headers-Hashing_HHHash) of a provided url:
 
 ```bash
-rgh header -u www.google.de
+rgh header https://www.google.de
 ```
 
 You can list all supported algorithms over the help function.


### PR DESCRIPTION
1.Error: reqwest::Error { kind: Builder, source: RelativeUrlWithoutBase }
2. error: unexpected argument '-u' found