### PR TITLE
remove extra print ()

### DIFF
--- a/src/rgh/app.rs
+++ b/src/rgh/app.rs
@@ -194,7 +194,7 @@ fn hash_file(alg: Algorithm, input: &str, option: OutputOptions) {
 	let alg_s = format!("{:?}", alg).to_uppercase();
 	let result = RHash::new(&alg_s).process_file(input, option);
 	match result {
-		Ok(r) => println!("{:?}", r),
+		Ok(_) => {},
 		Err(e) => {
 			eprintln!("Error: {}", e);
 			std::process::exit(1);


### PR DESCRIPTION
When you get a result from the cli. it prints an extra `()` at the end.

This remove it.

Before
```
923aa97483b1930a3e0317e65c2668cf3837a334ed3999e0ab46ceb0387eb28d Cargo.toml
()
```

after 
```
923aa97483b1930a3e0317e65c2668cf3837a334ed3999e0ab46ceb0387eb28d Cargo.toml
```