### PR TITLE
fix: use CryptoPro S-box for GOST94

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ printf "config\npipeline\n" | rgh mac --alg poly1305 --key tests/fixtures/keys/p
 - **SHA-3 family**: SHA3-224, SHA3-256, SHA3-384, SHA3-512.
 - **BLAKE family**: BLAKE2b, BLAKE2s, BLAKE3 (memory-hard friendly, modern).
 - **FSB family**: FSB-160, FSB-224, FSB-256, FSB-384, FSB-512.
-- **GOST & Streebog**: GOST R 34.11-94, GOST R 34.11-94-UA, Streebog-256, Streebog-512.
+- **GOST & Streebog**: GOST R 34.11-94 (CryptoPro S-box; `gost94-test` for the standard test S-box), GOST R 34.11-94-UA, Streebog-256, Streebog-512.
 - **JH finalists**: JH-224, JH-256, JH-384, JH-512.
 - **Skein family**: Skein-256, Skein-512, Skein-1024.
 - **Shabal family**: Shabal-192, Shabal-224, Shabal-256, Shabal-384, Shabal-512.

--- a/src/rgh/benchmark/digest.rs
+++ b/src/rgh/benchmark/digest.rs
@@ -112,6 +112,9 @@ fn benchmark_algorithm(
 		Algorithm::Fsb384 => benchmark_rhash("FSB384", iterations),
 		Algorithm::Fsb512 => benchmark_rhash("FSB512", iterations),
 		Algorithm::Gost94 => benchmark_rhash("GOST94", iterations),
+		Algorithm::Gost94Test => {
+			benchmark_rhash("GOST94TEST", iterations)
+		}
 		Algorithm::Gost94ua => {
 			benchmark_rhash("GOST94UA", iterations)
 		}

--- a/src/rgh/cli/algorithms.rs
+++ b/src/rgh/cli/algorithms.rs
@@ -19,6 +19,7 @@ pub enum Algorithm {
 	Fsb384,
 	Fsb512,
 	Gost94,
+	Gost94Test,
 	Gost94ua,
 	Groestl,
 	Jh224,

--- a/src/rgh/hash.rs
+++ b/src/rgh/hash.rs
@@ -649,7 +649,8 @@ impl RHash {
 				"FSB256"    => fsb::Fsb256::new(),
 				"FSB384"    => fsb::Fsb384::new(),
 				"FSB512"    => fsb::Fsb512::new(),
-				"GOST94"    => gost94::Gost94Test::new(),
+				"GOST94"    => gost94::Gost94CryptoPro::new(),
+				"GOST94TEST" => gost94::Gost94Test::new(),
 				"GOST94UA"  => gost94::Gost94UA::new(),
 				"GROESTL"   => groestl::Groestl256::new(),
 				"JH224"     => jh::Jh224::new(),
@@ -1145,4 +1146,16 @@ fn entry_status_from_error(
 		};
 	}
 	EntryStatus::Error
+}
+
+#[cfg(test)]
+mod gost94_sbox_tests {
+	use super::RHash;
+
+	#[test]
+	fn gost94_default_differs_from_test_sbox() {
+		let crypto = RHash::new("GOST94").process_string(b"rustgenhash");
+		let test = RHash::new("GOST94TEST").process_string(b"rustgenhash");
+		assert_ne!(crypto, test);
+	}
 }


### PR DESCRIPTION
## Summary
- `GOST94` uses the CryptoPro S-box instead of the test S-box.
- Test parameters remain available as `gost94-test`.

## Test plan
- [ ] `cargo test --lib gost94_sbox`
- [ ] `rgh digest string -a gost94 x` and `-a gost94-test x` differ


Made with [Cursor](https://cursor.com)