### PR TITLE
fix: recognize PHC balloon hashes with six fields

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,14 @@ pub mod rgh {
 	}
 
 	#[test]
+	fn test_analyze_balloon_phc() {
+		let hash = HashAnalyzer::from_string(
+			"$balloon$v=1$s=1024,t=3,p=1$c2FsdHNhbHRzYWx0$hashvalue",
+		);
+		assert!(hash.is_balloon());
+	}
+
+	#[test]
 	fn test_analyze_bcrypt() {
 		let hash = HashAnalyzer::from_string(
             "$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy"

--- a/src/rgh/analyze.rs
+++ b/src/rgh/analyze.rs
@@ -32,11 +32,31 @@ impl HashAnalyzer {
 
 	pub fn is_balloon(&self) -> bool {
 		let parts: Vec<&str> = self.hash.split('$').collect();
-		parts.len() == 5
-			&& parts[1] == "balloon"
-			&& ["1", "2"].contains(&parts[2])
-			&& parts[3].split(',').count() == 3
-			&& parts[3].split(',').all(|p| p.split('=').count() == 2)
+		if parts.first() != Some(&"") || parts.get(1) != Some(&"balloon")
+		{
+			return false;
+		}
+		let version_ok = |part: &str| {
+			part.starts_with("v=") || ["1", "2"].contains(&part)
+		};
+		let params_ok = |part: &str| {
+			part.split(',').count() == 3
+				&& part.split(',').all(|p| p.split('=').count() == 2)
+		};
+		match parts.as_slice() {
+			[_, _, version, params, _] if version_ok(version) && params_ok(params) => {
+				true
+			}
+			[_, _, version, params, salt, hash]
+				if version_ok(version)
+					&& params_ok(params)
+					&& !salt.is_empty()
+					&& !hash.is_empty() =>
+			{
+				true
+			}
+			_ => false,
+		}
 	}
 
 	pub fn is_argon2(&self) -> bool {


### PR DESCRIPTION
## Summary
- `is_balloon` accepts both the old 5-field form and PHC 6-field hashes (`$balloon$v=1$…$salt$hash`).

## Test plan
- [ ] `cargo test --lib test_analyze_balloon`


Made with [Cursor](https://cursor.com)