### PR TITLE
fix: detect bcrypt 2b/2y and bcrypt-pbkdf hex

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,25 @@ pub mod rgh {
 	}
 
 	#[test]
+	fn test_analyze_bcrypt_2b() {
+		let hash = HashAnalyzer::from_string(
+			"$2b$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy",
+		);
+		assert!(hash.is_bcrypt());
+	}
+
+	#[test]
+	fn test_analyze_bcrypt_pbkdf_hex() {
+		let hash = HashAnalyzer::from_string(
+			"6a3e6ed5ac928d1633d76182d1617410e565aff5bd8796f2d92dcefe27d6e04c50756887eeb56a1f09110187424af91964fe6f873a1a680ef7e44a50c0431ed6",
+		);
+		assert!(hash.is_bcrypt_pbkdf());
+		assert!(hash
+			.detect_possible_hashes()
+			.contains(&"bcrypt-pbkdf".to_string()));
+	}
+
+	#[test]
 	fn test_analyze_pbkdf2() {
 		let hash = HashAnalyzer::from_string(
         "$pbkdf2$SHA256$131000$7573657273616c74$b6987782641e8b3c9936a3685b2c6ced2b8a0668d4f681fd52d0efdc5e2e261c"

--- a/src/rgh/analyze.rs
+++ b/src/rgh/analyze.rs
@@ -51,9 +51,14 @@ impl HashAnalyzer {
 	pub fn is_bcrypt(&self) -> bool {
 		let parts: Vec<&str> = self.hash.split('$').collect();
 		parts.len() == 4
-			&& parts[1] == "2a"
+			&& ["2a", "2b", "2y"].contains(&parts[1])
 			&& parts[2].parse::<u32>().is_ok()
 			&& parts[3].len() == 53
+	}
+
+	pub fn is_bcrypt_pbkdf(&self) -> bool {
+		self.hash.len() == 128
+			&& self.hash.chars().all(|c| c.is_ascii_hexdigit())
 	}
 
 	pub fn is_pbkdf2(&self) -> bool {
@@ -115,6 +120,7 @@ impl HashAnalyzer {
 		let specific_checks = [
 			(self.is_balloon(), "Balloon"),
 			(self.is_bcrypt(), "bcrypt"),
+			(self.is_bcrypt_pbkdf(), "bcrypt-pbkdf"),
 			(self.is_argon2(), "Argon2"),
 			(self.is_pbkdf2(), "PBKDF2"), // Make sure this line is present
 			(self.is_scrypt(), "scrypt"),


### PR DESCRIPTION
## Summary
- Modular bcrypt now matches `$2a$`, `$2b$`, and `$2y$`.
- 128-character hex is reported as `bcrypt-pbkdf`.

## Test plan
- [ ] `cargo test --lib test_analyze_bcrypt`


Made with [Cursor](https://cursor.com)