### PR TITLE
Disable mmap for file digests by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- File digest mmap is off by default. Pass `--mmap-threshold <SIZE>` to enable it.
+
 ## 0.15.0 - 2026-08-15
 
 - Algorithm IDs accept hyphens (`sha3-256`). Unknown IDs return an error instead of panicking.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Directory hashing options:
 - `--recursive` traverses nested directories; defaults to the legacy non-recursive behaviour.
 - `--follow-symlinks {never,files,all}` controls whether symbolic links are hashed or followed.
 - `--threads {1|auto|N}` hashes files in parallel with Rayon when the value is `auto` or `N`. The default is `1`.
-- `--mmap-threshold <SIZE|off>` maps files at or above the threshold (default `64MiB`). Smaller files stream in 64 KiB blocks. Use `off` to disable mmap.
+- `--mmap-threshold <SIZE|off>` maps files at or above the threshold. Default is `off` (64 KiB block reads). Pass a size to enable mmap.
 - `--manifest <FILE>` writes a JSON summary containing per-file digests, failures, and performance metadata (fail-fast suppresses the file to avoid partial output). When `--format multihash` is selected, the manifest preserves the emitted base58btc tokens.
 - `--error-strategy {fail-fast,continue,report-only}` determines how failures affect exit codes and manifest writes:
   - `fail-fast` stops on the first unreadable entry, exits `1`, and skips manifest creation.

--- a/src/rgh/app.rs
+++ b/src/rgh/app.rs
@@ -509,7 +509,7 @@ fn handle_digest_command(
 			let mmap_value = args
 				.get_one::<String>("mmap-threshold")
 				.map(String::as_str)
-				.unwrap_or("64MiB");
+				.unwrap_or("off");
 			let mmap_threshold = parse_mmap_threshold(mmap_value)
 				.map_err(|msg| {
 					io::Error::new(io::ErrorKind::InvalidInput, msg)
@@ -1174,8 +1174,8 @@ pub(crate) fn build_cli() -> clap::Command {
 							.arg(
 								Arg::new("mmap-threshold")
 									.long("mmap-threshold")
-									.default_value("64MiB")
-									.help("Enable mmap for files ≥ threshold (use 'off' to disable)"),
+									.default_value("off")
+									.help("Map files at or above this size (default off)"),
 							)
 							.arg(
 								Arg::new("progress")

--- a/src/rgh/audit/runner.rs
+++ b/src/rgh/audit/runner.rs
@@ -659,7 +659,7 @@ fn run_digest_file_case(
 		.input
 		.get("mmap_threshold")
 		.and_then(Value::as_str)
-		.unwrap_or("64MiB");
+		.unwrap_or("off");
 	let mmap_threshold = parse_mmap_threshold(mmap_raw, &case.id)?;
 	let error_strategy_raw = case
 		.input

--- a/src/rgh/cli/handlers.rs
+++ b/src/rgh/cli/handlers.rs
@@ -124,7 +124,7 @@ pub fn hash_file(
 		follow_symlinks: SymlinkPolicy::Never,
 		order: WalkOrder::Lexicographic,
 		threads: ThreadStrategy::Single,
-		mmap_threshold: Some(64 * 1024 * 1024),
+		mmap_threshold: None,
 	};
 	let progress = ProgressConfig {
 		mode: ProgressMode::Auto,

--- a/src/rgh/cli/interactive.rs
+++ b/src/rgh/cli/interactive.rs
@@ -148,7 +148,7 @@ fn interactive_digest_file() -> Result<(), Box<dyn Error>> {
 		follow_symlinks: SymlinkPolicy::Never,
 		order: WalkOrder::Lexicographic,
 		threads: ThreadStrategy::Single,
-		mmap_threshold: Some(64 * 1024 * 1024),
+		mmap_threshold: None,
 	};
 	let progress = ProgressConfig {
 		mode: ProgressMode::Auto,

--- a/src/rgh/cli/parser.rs
+++ b/src/rgh/cli/parser.rs
@@ -305,3 +305,21 @@ pub fn build_progress_config(args: &clap::ArgMatches) -> ProgressConfig {
 	}
 }
 
+#[cfg(test)]
+mod mmap_threshold_parse_tests {
+	use super::parse_mmap_threshold;
+
+	#[test]
+	fn off_disables_mmap() {
+		assert_eq!(parse_mmap_threshold("off").unwrap(), None);
+		assert_eq!(parse_mmap_threshold("OFF").unwrap(), None);
+	}
+
+	#[test]
+	fn size_enables_mmap() {
+		assert_eq!(
+			parse_mmap_threshold("64MiB").unwrap(),
+			Some(64 * 1024 * 1024)
+		);
+	}
+}

--- a/src/rgh/file/mod.rs
+++ b/src/rgh/file/mod.rs
@@ -133,3 +133,34 @@ pub struct PerformanceEnvelope {
 	pub threads: usize,
 	pub mmap_active: bool,
 }
+
+#[cfg(test)]
+mod mmap_threshold_tests {
+	use super::{DirectoryHashPlan, ThreadStrategy, WalkOrder};
+	use crate::rgh::file::SymlinkPolicy;
+	use std::path::PathBuf;
+
+	fn plan(threshold: Option<u64>) -> DirectoryHashPlan {
+		DirectoryHashPlan {
+			root_path: PathBuf::from("."),
+			recursive: false,
+			follow_symlinks: SymlinkPolicy::Never,
+			order: WalkOrder::Lexicographic,
+			threads: ThreadStrategy::Single,
+			mmap_threshold: threshold,
+		}
+	}
+
+	#[test]
+	fn mmap_stays_off_without_threshold() {
+		assert!(!plan(None).should_use_mmap(0));
+		assert!(!plan(None).should_use_mmap(u64::MAX));
+	}
+
+	#[test]
+	fn mmap_turns_on_at_explicit_threshold() {
+		let threshold = 64 * 1024 * 1024;
+		assert!(!plan(Some(threshold)).should_use_mmap(threshold - 1));
+		assert!(plan(Some(threshold)).should_use_mmap(threshold));
+	}
+}


### PR DESCRIPTION
Mapped files can SIGBUS or mix content if the file shrinks or changes during the hash.