### PR TITLE
MAC/KDF known-answer tests, digest drift, hhhash sort

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.wasm32-unknown-unknown]
+rustflags = ["--cfg", "getrandom_backend=\"wasm_js\""]

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Keep fixture bytes identical across platforms (audit/KAT digests).
+tests/fixtures/** text eol=lf

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,9 +27,14 @@ jobs:
           - name: Windows x86_64 tests
             runs-on: windows-latest
             target: ""
-            # MSVC cannot assemble sha2-asm (*.S); use portable digests + CLI.
-            command: cargo test --all --no-default-features --features "std,cli"
+            # MSVC cannot assemble sha2-asm (*.S). Audit lives in the Linux Audit Harness
+            # workflow (symlinks/path separators differ on Windows).
+            command: cargo test --all --no-default-features --features "std,cli" -- --skip audit_fixtures_smoke
     steps:
+      - name: Force LF checkouts on Windows
+        if: runner.os == 'Windows'
+        shell: bash
+        run: git config --global core.autocrlf false
       - uses: actions/checkout@v4
       - name: Install stable Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,8 @@ jobs:
           - name: Windows x86_64 tests
             runs-on: windows-latest
             target: ""
-            command: cargo test --all
+            # MSVC cannot assemble sha2-asm (*.S); use portable digests + CLI.
+            command: cargo test --all --no-default-features --features "std,cli"
     steps:
       - uses: actions/checkout@v4
       - name: Install stable Rust

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Audit harness skips `kats/` directories (KAT schema ≠ audit fixtures).
+- `cli` feature gates dialoguer/rustyline so wasm `portable-only` builds without them.
+- Analyze SHA-256 detect fixture includes Snefru-256.
 - Sourced MAC known-answer fixtures for every registry MAC ID (`tests/mac_kats.rs`).
 - `KDF_ALGORITHM_IDS` and sourced KDF known-answer fixtures (`tests/kdf_kats.rs`).
 - Drift test: digest-capable `Algorithm` variants stay in `DIGEST_ALGORITHMS`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+- Sourced MAC known-answer fixtures for every registry MAC ID (`tests/mac_kats.rs`).
+- `KDF_ALGORITHM_IDS` and sourced KDF known-answer fixtures (`tests/kdf_kats.rs`).
+- Drift test: digest-capable `Algorithm` variants stay in `DIGEST_ALGORITHMS`.
+- Non-empty (`abc`) digest KATs for algorithms that previously had only empty vectors.
+- `hhh:1:` HHHash uses sorted lowercased header names; `compare_hashes` display semantics documented.
+
 ## 0.16.0 - 2026-09-09
 
 - ASCON digests go through `RHash` / `rgh digest` (no legacy-only path).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
-## Unreleased
+## 0.16.0 - 2026-09-09
 
-- Published known-answer fixtures for every digest algorithm under `tests/fixtures/digest/kats/`, with source citations and CI coverage gates against `DIGEST_ALGORITHMS`.
+- ASCON digests go through `RHash` / `rgh digest` (no legacy-only path).
+- Sourced known-answer fixtures for every digest in `DIGEST_ALGORITHMS` under `tests/fixtures/digest/kats/`; `tests/digest_kats.rs` enforces coverage and output widths.
 - Snefru-128 and Snefru-256 (8-pass) digests. IDs: `snefru`, `snefru128`, `snefru256`.
 - File digest mmap is off by default. Pass `--mmap-threshold <SIZE>` to enable it.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1891,7 +1891,7 @@ dependencies = [
 
 [[package]]
 name = "rustgenhash"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "aes",
  "argon2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -878,9 +878,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1913,6 +1915,7 @@ dependencies = [
  "digest 0.10.7",
  "fsb",
  "getrandom 0.2.17",
+ "getrandom 0.3.4",
  "gost94",
  "groestl",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,12 @@ categories = ["command-line-utilities", "cryptography"]
 [[bin]]
 name = "rgh"
 path = "src/bin/main.rs"
+required-features = ["cli"]
 
 [[bin]]
 name = "print_multihash"
 path = "scripts/tools/print_multihash.rs"
+required-features = ["cli"]
 
 [profile.release]
 strip = "symbols"
@@ -28,7 +30,7 @@ opt-level = "z"
 panic = "abort"
 
 [features]
-default = ["std", "asm-accel"]
+default = ["std", "asm-accel", "cli"]
 std = []
 asm-accel = [
 	"sha-1/asm",
@@ -37,6 +39,7 @@ asm-accel = [
 	"md-5/asm",
 	"whirlpool/asm",
 ]
+cli = ["dep:dialoguer", "dep:rustyline"]
 portable-only = ["std"]
 
 [dependencies]
@@ -55,8 +58,8 @@ clap = { version = "4.0.10", features = ["derive", "cargo"] }
 clap_complete = "4.0.2"
 colored = "2.1.0"
 csv = "1.3"
-dialoguer = "0.11.0"
-rustyline = "13.0"
+dialoguer = { version = "0.11.0", optional = true }
+rustyline = { version = "13.0", optional = true }
 digest = { version = "0.10.5", features = ["std"] }
 hmac = "0.12"
 hkdf = "0.12"
@@ -114,6 +117,9 @@ predicates = "3.1"
 [target.'cfg(target_arch = "wasm32")'.dependencies.getrandom]
 version = "0.2.16"
 features = ["js"]
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom_03 = { package = "getrandom", version = "0.3", features = ["wasm_js"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.uuid]
 version = "1.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustgenhash"
-version = "0.15.0"
+version = "0.16.0"
 license = "MIT"
 authors = ["Volker Schwaberow <volker@schwaberow.de>"]
 description = "A tool to generate hashes from the command line."

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Rustgenhash groups its command line surface into two primary families:
 - `rgh digest <mode>` — deterministic hashing for strings, files, or stdin streams.
 - `rgh kdf <algorithm>` — password-based key derivation with structured (JSON) metadata.
 
-Supporting utilities remain available: `analyze`, `benchmark`, `compare-hash`, `compare-file`, `random`, `header`, and
+Supporting utilities remain available: `analyze`, `benchmark`, `compare-hash` (case-insensitive display equality of digests, not constant-time and not for MAC tags), `compare-file`, `random`, `header`, and
 `interactive` (a guided wizard that now branches between digest and KDF workflows).
 
 ### Digest commands
@@ -302,13 +302,14 @@ rgh random -a uuidv4 -l 16
 
 `uuidv4` produces 16 bytes. Other lengths return an error.
 
-Scheme for generating a [HHHash](https://www.foo.be/2023/07/HTTP-Headers-Hashing_HHHash) of a provided url:
+Scheme for generating a [HHHash](https://www.foo.be/2023/07/HTTP-Headers-Hashing_HHHash) of a provided url.
+The `hhh:1:` digest hashes **sorted** lowercased header names (not wire / insertion order):
 
 ```bash
 rgh header www.google.de
 ```
 
-Scheme for comparing a hash:
+Scheme for comparing a hash (`compare-string` / `compare-hash`: case-insensitive display equality, not constant-time, not for MAC tags):
 
 ```bash
 rgh compare-string <hash1> <hash2>

--- a/README.md
+++ b/README.md
@@ -334,13 +334,13 @@ rgh benchmark -a <algorithm> -i <iterations>
 
 ### Digest correctness
 
-Every digest algorithm registered in `DIGEST_ALGORITHMS` has sourced known-answer tests under [`tests/fixtures/digest/kats/`](tests/fixtures/digest/kats/). Fixtures cite the originating standard or published KAT suite (`source.title` / `source.url`). `tests/digest_kats.rs` checks that:
+Every algorithm in `DIGEST_ALGORITHMS` (including ASCON, Skein full-width outputs, GOST94 CryptoPro/Test/UA, and Snefru-128/256) has sourced known-answer tests under [`tests/fixtures/digest/kats/`](tests/fixtures/digest/kats/). Each fixture cites its standard or published KAT suite (`source.title` / `source.url`). `tests/digest_kats.rs` checks that:
 
 - each fixture digest matches `RHash`
 - every registry algorithm has at least one fixture
 - digest widths match the registry (catches silent truncation such as wrong Skein output sizes)
 
-`cargo test --all` runs these gates in CI.
+Run `cargo test --test digest_kats` or `cargo test --all` (CI).
 
 ## Performance Profile
 
@@ -368,6 +368,7 @@ across every CLI mode to guard against logical regressions.
 
 ```bash
 cargo test --test audit
+cargo test --test digest_kats
 ```
 
 The audit produces deterministic artifacts under `target/audit/`:
@@ -392,6 +393,7 @@ and the JSON payload to pinpoint the mismatch.
 | Fixture ID | Focus | Expected Exit | Notes |
 |------------|-------|---------------|-------|
 | `digest_string_empty` | SHA-256 digest of empty input | `0` | Ensures default and `--hash-only` outputs remain identical. |
+| `digest_string_snefru128` | Snefru-128 of `abc` plus weak banner | `0` | 8-pass Snefru; weak-algorithm warning required. |
 | `digest_file_large_stream` | 1 GiB deterministic stream | `0` | Runtime target ≤10 min; data generated under `target/audit/large-stream/`. |
 | `mac_poly1305_mismatched_key` | Poly1305 key length violation | `2` | Requires error text “Poly1305 requires a 32-byte one-time key…”. |
 | `mac_cmac_padding_mismatch` | CMAC invalid key length | `2` | Fails fast with “Invalid CMAC key length…” guidance. |

--- a/README.md
+++ b/README.md
@@ -341,7 +341,11 @@ Every algorithm in `DIGEST_ALGORITHMS` (including ASCON, Skein full-width output
 - every registry algorithm has at least one fixture
 - digest widths match the registry (catches silent truncation such as wrong Skein output sizes)
 
-Run `cargo test --test digest_kats` or `cargo test --all` (CI).
+Every MAC ID from `mac::registry::algorithms()` has a sourced fixture under [`tests/fixtures/mac/kats/`](tests/fixtures/mac/kats/). `tests/mac_kats.rs` enforces match, coverage, and no orphans.
+
+Every ID in `KDF_ALGORITHM_IDS` has a sourced fixed-parameter fixture under [`tests/fixtures/kdf/kats/`](tests/fixtures/kdf/kats/). `tests/kdf_kats.rs` enforces the same gates.
+
+Run `cargo test --test digest_kats --test mac_kats --test kdf_kats` or `cargo test --all` (CI).
 
 ## Performance Profile
 
@@ -369,7 +373,7 @@ across every CLI mode to guard against logical regressions.
 
 ```bash
 cargo test --test audit
-cargo test --test digest_kats
+cargo test --test digest_kats --test mac_kats --test kdf_kats
 ```
 
 The audit produces deterministic artifacts under `target/audit/`:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,10 +8,12 @@ pub use serde::{Deserialize, Serialize};
 
 pub mod rgh {
         pub mod analyze;
+        #[cfg(feature = "cli")]
         pub mod app;
         pub mod audit;
         pub mod benchmark;
         pub mod cli;
+        #[cfg(feature = "cli")]
         pub mod console;
         pub mod digest;
         pub mod file;

--- a/src/rgh/analyze.rs
+++ b/src/rgh/analyze.rs
@@ -174,6 +174,10 @@ impl HashAnalyzer {
 	}
 }
 
+/// Case-insensitive equality of two hex (or other display) hash strings.
+///
+/// This is a CLI display check for `compare-hash`, not a constant-time
+/// comparison and not a MAC verification API.
 pub fn compare_hashes(hash1: &str, hash2: &str) -> bool {
 	hash1.eq_ignore_ascii_case(hash2)
 }

--- a/src/rgh/audit/fs.rs
+++ b/src/rgh/audit/fs.rs
@@ -81,6 +81,10 @@ fn collect_recursive(
 			})?;
 		let path = entry.path();
 		if meta.is_dir() {
+			// Known-answer fixtures use a different schema than audit cases.
+			if path.file_name() == Some(OsStr::new("kats")) {
+				continue;
+			}
 			collect_recursive(&path, paths)?;
 			continue;
 		}

--- a/src/rgh/audit/runner.rs
+++ b/src/rgh/audit/runner.rs
@@ -16,7 +16,7 @@ use super::{
 	AuditCase, AuditError, AuditMode, AuditRunMetadata, AuditSeverity,
 };
 use crate::rgh::analyze::{compare_hashes, HashAnalyzer};
-use crate::rgh::app::Algorithm;
+use crate::rgh::cli::algorithms::Algorithm;
 use crate::rgh::benchmark::run_digest_benchmarks;
 use crate::rgh::file::{
 	DirectoryHashPlan, EntryStatus, ErrorHandlingProfile,

--- a/src/rgh/benchmark/digest.rs
+++ b/src/rgh/benchmark/digest.rs
@@ -8,7 +8,7 @@ use super::{
 	BenchmarkError, BenchmarkMode, BenchmarkResult,
 	BenchmarkScenario, BenchmarkSummary,
 };
-use crate::rgh::app::Algorithm;
+use crate::rgh::cli::algorithms::Algorithm;
 use crate::rgh::hash::{
 	asm_accelerated_digests, Argon2Config, BalloonConfig,
 	BcryptConfig, PHash, Pbkdf2Config, RHash, ScryptConfig,

--- a/src/rgh/benchmark/mod.rs
+++ b/src/rgh/benchmark/mod.rs
@@ -5,6 +5,7 @@
 // Copyright (c) 2025
 
 use chrono::{DateTime, Utc};
+#[cfg(feature = "cli")]
 use dialoguer::Confirm;
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
@@ -617,17 +618,25 @@ pub fn confirm_runtime(
 		if algorithm_count == 1 { "" } else { "s" },
 		format_runtime(estimate)
 	);
-	let confirmed = Confirm::new()
-		.with_prompt(prompt)
-		.default(true)
-		.interact()
-		.map_err(|err| {
-			BenchmarkError::Io(io::Error::other(err.to_string()))
-		})?;
-	if confirmed {
-		Ok(())
-	} else {
-		Err(BenchmarkError::UserAborted)
+	#[cfg(not(feature = "cli"))]
+	{
+		let _ = prompt;
+		return Err(BenchmarkError::UserAborted);
+	}
+	#[cfg(feature = "cli")]
+	{
+		let confirmed = Confirm::new()
+			.with_prompt(prompt)
+			.default(true)
+			.interact()
+			.map_err(|err| {
+				BenchmarkError::Io(io::Error::other(err.to_string()))
+			})?;
+		if confirmed {
+			Ok(())
+		} else {
+			Err(BenchmarkError::UserAborted)
+		}
 	}
 }
 

--- a/src/rgh/cli/algorithms.rs
+++ b/src/rgh/cli/algorithms.rs
@@ -120,3 +120,62 @@ impl Algorithm {
         self.properties().file_support
     }
 }
+impl Algorithm {
+	pub fn is_password_kdf(self) -> bool {
+		matches!(
+			self,
+			Self::Argon2
+				| Self::Balloon
+				| Self::Bcrypt
+				| Self::Pbkdf2Sha256
+				| Self::Pbkdf2Sha512
+				| Self::Scrypt
+				| Self::Shacrypt
+		)
+	}
+
+	/// Canonical [`crate::rgh::hash::RHash`] id when this variant is a digest.
+	pub fn digest_rhash_id(self) -> Option<String> {
+		if self.is_password_kdf() {
+			None
+		} else {
+			Some(format!("{:?}", self).to_ascii_uppercase())
+		}
+	}
+}
+
+#[cfg(test)]
+mod digest_registry_drift {
+	use super::*;
+	use crate::rgh::hash::{
+		DIGEST_ALGORITHM_ALIASES, DIGEST_ALGORITHMS, RHash,
+	};
+	use strum::IntoEnumIterator;
+
+	fn resolve_digest_id(id: &str) -> &str {
+		DIGEST_ALGORITHM_ALIASES
+			.iter()
+			.find(|(alias, _)| *alias == id)
+			.map(|(_, target)| *target)
+			.unwrap_or(id)
+	}
+
+	#[test]
+	fn digest_capable_algorithms_are_in_digest_registry() {
+		let registry: std::collections::HashSet<&str> =
+			DIGEST_ALGORITHMS.iter().map(|algo| algo.id).collect();
+		for alg in Algorithm::iter() {
+			let Some(id) = alg.digest_rhash_id() else {
+				continue;
+			};
+			let canonical = resolve_digest_id(&id);
+			assert!(
+				registry.contains(canonical),
+				"Algorithm::{alg:?} maps to `{id}` → `{canonical}` missing from DIGEST_ALGORITHMS"
+			);
+			RHash::new(canonical).unwrap_or_else(|err| {
+				panic!("RHash::new({canonical}) failed for {alg:?}: {err}")
+			});
+		}
+	}
+}

--- a/src/rgh/cli/defs.rs
+++ b/src/rgh/cli/defs.rs
@@ -19,11 +19,13 @@ pub static DIGEST_ALGORITHM_HELP: OnceLock<String> = OnceLock::new();
 
 pub fn digest_algorithm_help_text() -> &'static str {
 	DIGEST_ALGORITHM_HELP.get_or_init(|| {
-		let display_names = all_metadata()
-			.iter()
-			.map(|meta| meta.display_name)
-			.collect::<Vec<_>>()
-			.join(", ");
+		let mut display_names = Vec::new();
+		for meta in all_metadata() {
+			if !display_names.contains(&meta.display_name) {
+				display_names.push(meta.display_name);
+			}
+		}
+		let display_names = display_names.join(", ");
 		let identifiers = all_metadata()
 			.iter()
 			.map(|meta| meta.algorithm_id)

--- a/src/rgh/cli/mod.rs
+++ b/src/rgh/cli/mod.rs
@@ -5,5 +5,6 @@ pub mod algorithms;
 pub mod benchmark;
 pub mod defs;
 pub mod handlers;
+#[cfg(feature = "cli")]
 pub mod interactive;
 pub mod parser;

--- a/src/rgh/hash.rs
+++ b/src/rgh/hash.rs
@@ -517,24 +517,30 @@ impl PHash {
 		password: &str,
 		hash_only: bool,
 	) -> Result<String, String> {
-		let params = sha_crypt::Params::new(10_000).map_err(|err| format!("{:?}", err))?;
 		let salt = SaltString::generate(&mut OsRng);
+		Self::hash_sha_crypt_with_salt(password, salt.as_str().as_bytes())
+			.map(|digest| {
+				assemble_output(hash_only, vec![digest], Some(password))
+			})
+	}
+
+	pub fn hash_sha_crypt_with_salt(
+		password: &str,
+		salt: &[u8],
+	) -> Result<String, String> {
+		let params = sha_crypt::Params::new(10_000)
+			.map_err(|err| format!("{:?}", err))?;
 		let sha_crypt = sha_crypt::ShaCrypt::new(
 			sha_crypt::Algorithm::Sha512Crypt,
 			params,
 		);
-		let hash =
-			sha_crypt::PasswordHasher::hash_password_with_salt(
-				&sha_crypt,
-				password.as_bytes(),
-				salt.as_str().as_bytes(),
-			)
-			.map_err(|err| format!("{:?}", err))?;
-		Ok(assemble_output(
-			hash_only,
-			vec![hash.to_string()],
-			Some(password),
-		))
+		let hash = sha_crypt::PasswordHasher::hash_password_with_salt(
+			&sha_crypt,
+			password.as_bytes(),
+			salt,
+		)
+		.map_err(|err| format!("{:?}", err))?;
+		Ok(hash.to_string())
 	}
 
 	pub fn hash_pbkdf2(
@@ -588,7 +594,7 @@ impl PHash {
 		))
 	}
 
-	pub(crate) fn hash_pbkdf2_with_salt(
+	pub fn hash_pbkdf2_with_salt(
 		password: &str,
 		pb_scheme: &str,
 		cfg: &Pbkdf2Config,
@@ -637,7 +643,7 @@ impl PHash {
 		Ok(hex::encode(out))
 	}
 
-	pub(crate) fn hash_bcrypt_with_salt(
+	pub fn hash_bcrypt_with_salt(
 		password: &str,
 		cfg: &BcryptConfig,
 		salt_b64: &str,
@@ -651,7 +657,7 @@ impl PHash {
 			.map_err(|err| err.to_string())
 	}
 
-	pub(crate) fn hash_argon2_with_salt(
+	pub fn hash_argon2_with_salt(
 		password: &str,
 		cfg: &Argon2Config,
 		salt_b64: &str,
@@ -665,7 +671,7 @@ impl PHash {
 			.map_err(|err| err.to_string())
 	}
 
-	pub(crate) fn hash_balloon_with_salt(
+	pub fn hash_balloon_with_salt(
 		password: &str,
 		cfg: &BalloonConfig,
 		salt_b64: &str,
@@ -679,7 +685,7 @@ impl PHash {
 			.map_err(|err| err.to_string())
 	}
 
-	pub(crate) fn hash_scrypt_with_salt(
+	pub fn hash_scrypt_with_salt(
 		password: &str,
 		cfg: &ScryptConfig,
 		salt_b64: &str,

--- a/src/rgh/hhhash.rs
+++ b/src/rgh/hhhash.rs
@@ -49,6 +49,31 @@ pub fn generate_hhhash(
 	Err("HHHash generation is not supported on wasm targets".into())
 }
 
+/// Canonical HHHash header list: lowercased names, sorted, joined by newlines.
+///
+/// `hhh:1:` digests use this order so the result is independent of response
+/// header insertion / wire order.
+pub fn canonicalize_header_names<'a>(
+	names: impl IntoIterator<Item = &'a str>,
+) -> String {
+	let mut names: Vec<String> = names
+		.into_iter()
+		.map(|name| name.to_ascii_lowercase())
+		.collect();
+	names.sort_unstable();
+	names.join("\n")
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn hhhash_from_header_names<'a>(
+	names: impl IntoIterator<Item = &'a str>,
+) -> String {
+	let header_string = canonicalize_header_names(names);
+	let mut hasher = sha2::Sha256::new();
+	hasher.update(header_string.as_bytes());
+	format!("hhh:1:{}", hex::encode(hasher.finalize()))
+}
+
 #[cfg(not(target_arch = "wasm32"))]
 pub fn generate_hhhash(
 	url: String,
@@ -60,17 +85,31 @@ pub fn generate_hhhash(
 
 	let resp = client.get(parsed_url).send()?.error_for_status()?;
 
-	let header_names: Vec<_> = resp
-		.headers()
-		.keys()
-		.map(|header| header.as_str())
-		.collect();
-	let header_string = header_names.join("\n");
+	Ok(hhhash_from_header_names(
+		resp.headers().keys().map(|header| header.as_str()),
+	))
+}
 
-	let mut hasher = sha2::Sha256::new();
-	hasher.update(header_string.as_bytes());
-	let hash = hasher.finalize();
-	let hash = format!("hhh:1:{}", hex::encode(hash));
+#[cfg(test)]
+mod tests {
+	use super::*;
 
-	Ok(hash)
+	#[test]
+	fn header_order_does_not_change_hhhash() {
+		let a = ["Content-Type", "Date", "Server"];
+		let b = ["server", "content-type", "DATE"];
+		assert_eq!(
+			canonicalize_header_names(a),
+			"content-type\ndate\nserver"
+		);
+		assert_eq!(
+			canonicalize_header_names(a),
+			canonicalize_header_names(b)
+		);
+		#[cfg(not(target_arch = "wasm32"))]
+		assert_eq!(
+			hhhash_from_header_names(a),
+			hhhash_from_header_names(b)
+		);
+	}
 }

--- a/src/rgh/kdf/mod.rs
+++ b/src/rgh/kdf/mod.rs
@@ -5,6 +5,23 @@
 //
 // Password-based key derivation command group.
 
+
+/// Canonical KDF identifiers covered by sourced known-answer fixtures.
+pub const KDF_ALGORITHM_IDS: &[&str] = &[
+	"argon2",
+	"balloon",
+	"bcrypt",
+	"hkdf-blake3",
+	"hkdf-sha256",
+	"hkdf-sha3-256",
+	"hkdf-sha3-512",
+	"hkdf-sha512",
+	"pbkdf2-sha256",
+	"pbkdf2-sha512",
+	"scrypt",
+	"sha-crypt",
+];
+
 use serde_json::{json, Value as JsonValue};
 use std::fs;
 use std::io::{self, Read};

--- a/tests/fixtures/analyze/sha256_detect.json
+++ b/tests/fixtures/analyze/sha256_detect.json
@@ -17,6 +17,7 @@
       "SHA3-256",
       "SM3",
       "Shabal256",
+      "Snefru-256",
       "Streebog256"
     ],
     "is_exact": false

--- a/tests/fixtures/digest/kats/belthash_abc.json
+++ b/tests/fixtures/digest/kats/belthash_abc.json
@@ -1,0 +1,12 @@
+{
+  "algorithm": "BELTHASH",
+  "input": {
+    "encoding": "utf8",
+    "value": "abc"
+  },
+  "expected_hex": "2661a79795a9e80258d6bc1e5d11747247901268ec4cd19237aad051e322b0c2",
+  "source": {
+    "title": "STB 34.101.31-2020 Belt hash (Table A.23)",
+    "url": "http://apmi.bsu.by/assets/files/std/belt-spec371.pdf"
+  }
+}

--- a/tests/fixtures/digest/kats/blake2b_abc.json
+++ b/tests/fixtures/digest/kats/blake2b_abc.json
@@ -1,0 +1,12 @@
+{
+  "algorithm": "BLAKE2B",
+  "input": {
+    "encoding": "utf8",
+    "value": "abc"
+  },
+  "expected_hex": "ba80a53f981c4d0d6a2797b69f12f6e94c212f14685ac4b74b12bb6fdbffa2d17d87c5392aab792dc252d5de4533cc9518d38aa8dbf1925ab92386edd4009923",
+  "source": {
+    "title": "RFC 7693 \u2014 BLAKE2b",
+    "url": "https://www.rfc-editor.org/rfc/rfc7693"
+  }
+}

--- a/tests/fixtures/digest/kats/blake2s_abc.json
+++ b/tests/fixtures/digest/kats/blake2s_abc.json
@@ -1,0 +1,12 @@
+{
+  "algorithm": "BLAKE2S",
+  "input": {
+    "encoding": "utf8",
+    "value": "abc"
+  },
+  "expected_hex": "508c5e8c327c14e2e1a72ba34eeb452f37458b209ed63a294d999b4c86675982",
+  "source": {
+    "title": "RFC 7693 \u2014 BLAKE2s",
+    "url": "https://www.rfc-editor.org/rfc/rfc7693"
+  }
+}

--- a/tests/fixtures/digest/kats/blake3_abc.json
+++ b/tests/fixtures/digest/kats/blake3_abc.json
@@ -1,0 +1,12 @@
+{
+  "algorithm": "BLAKE3",
+  "input": {
+    "encoding": "utf8",
+    "value": "abc"
+  },
+  "expected_hex": "6437b3ac38465133ffb63b75273a8db548c558465d79db03fd359c6cd5bd9d85",
+  "source": {
+    "title": "BLAKE3 specification",
+    "url": "https://github.com/BLAKE3-team/BLAKE3/blob/master/README.md"
+  }
+}

--- a/tests/fixtures/digest/kats/fsb160_abc.json
+++ b/tests/fixtures/digest/kats/fsb160_abc.json
@@ -1,0 +1,12 @@
+{
+  "algorithm": "FSB160",
+  "input": {
+    "encoding": "utf8",
+    "value": "abc"
+  },
+  "expected_hex": "c93c6cbd9f9a7d35fcd02d0e9822bd8589854aef",
+  "source": {
+    "title": "FSB hash \u2014 SHA-3 competition package / RustCrypto fsb tests",
+    "url": "https://github.com/RustCrypto/hashes"
+  }
+}

--- a/tests/fixtures/digest/kats/fsb224_abc.json
+++ b/tests/fixtures/digest/kats/fsb224_abc.json
@@ -1,0 +1,12 @@
+{
+  "algorithm": "FSB224",
+  "input": {
+    "encoding": "utf8",
+    "value": "abc"
+  },
+  "expected_hex": "a5c46ac3abbd72b27d680915500762ce10b43db7d1cc996c5669a7e3",
+  "source": {
+    "title": "FSB hash \u2014 SHA-3 competition package / RustCrypto fsb tests",
+    "url": "https://github.com/RustCrypto/hashes"
+  }
+}

--- a/tests/fixtures/digest/kats/fsb256_abc.json
+++ b/tests/fixtures/digest/kats/fsb256_abc.json
@@ -1,0 +1,12 @@
+{
+  "algorithm": "FSB256",
+  "input": {
+    "encoding": "utf8",
+    "value": "abc"
+  },
+  "expected_hex": "e13c678b7d557ae9b26b605c8f4e38ad582581629eb42198cbeb7e40046c7d69",
+  "source": {
+    "title": "FSB hash \u2014 SHA-3 competition package / RustCrypto fsb tests",
+    "url": "https://github.com/RustCrypto/hashes"
+  }
+}

--- a/tests/fixtures/digest/kats/fsb384_abc.json
+++ b/tests/fixtures/digest/kats/fsb384_abc.json
@@ -1,0 +1,12 @@
+{
+  "algorithm": "FSB384",
+  "input": {
+    "encoding": "utf8",
+    "value": "abc"
+  },
+  "expected_hex": "163cd26db98ea5a346d079cc999e50840b24fb55b9228ee06269b32128605606f94d58e169f686e6b92c6819890f1708",
+  "source": {
+    "title": "FSB hash \u2014 SHA-3 competition package / RustCrypto fsb tests",
+    "url": "https://github.com/RustCrypto/hashes"
+  }
+}

--- a/tests/fixtures/digest/kats/fsb512_abc.json
+++ b/tests/fixtures/digest/kats/fsb512_abc.json
@@ -1,0 +1,12 @@
+{
+  "algorithm": "FSB512",
+  "input": {
+    "encoding": "utf8",
+    "value": "abc"
+  },
+  "expected_hex": "ee2e8824748fb1dd8f0a7424e2a7a25ee5a03d92ba974dfc611ea74065981e7ab5e64f6962fe7363d1e4f79c526585e095dbe0e02adacb9073678964db08105f",
+  "source": {
+    "title": "FSB hash \u2014 SHA-3 competition package / RustCrypto fsb tests",
+    "url": "https://github.com/RustCrypto/hashes"
+  }
+}

--- a/tests/fixtures/digest/kats/gost94test_abc.json
+++ b/tests/fixtures/digest/kats/gost94test_abc.json
@@ -1,0 +1,12 @@
+{
+  "algorithm": "GOST94TEST",
+  "input": {
+    "encoding": "utf8",
+    "value": "abc"
+  },
+  "expected_hex": "f3134348c44fb1b2a277729e2285ebb5cb5e0f29c975bc753b70497c06a4d51d",
+  "source": {
+    "title": "GOST R 34.11-94 Test parameter set (RFC 4357)",
+    "url": "https://www.rfc-editor.org/rfc/rfc4357"
+  }
+}

--- a/tests/fixtures/digest/kats/groestl_abc.json
+++ b/tests/fixtures/digest/kats/groestl_abc.json
@@ -1,0 +1,12 @@
+{
+  "algorithm": "GROESTL",
+  "input": {
+    "encoding": "utf8",
+    "value": "abc"
+  },
+  "expected_hex": "f3c1bb19c048801326a7efbcf16e3d7887446249829c379e1840d1a3a1e7d4d2",
+  "source": {
+    "title": "Gr\u00f8stl \u2014 SHA-3 competition / RustCrypto groestl tests",
+    "url": "https://github.com/RustCrypto/hashes"
+  }
+}

--- a/tests/fixtures/digest/kats/jh224_abc.json
+++ b/tests/fixtures/digest/kats/jh224_abc.json
@@ -1,0 +1,12 @@
+{
+  "algorithm": "JH224",
+  "input": {
+    "encoding": "utf8",
+    "value": "abc"
+  },
+  "expected_hex": "21e88480ebb76dd51a984d52e97fa0da620f885b94a172320131ab54",
+  "source": {
+    "title": "JH hash \u2014 SHA-3 competition / RustCrypto jh tests",
+    "url": "https://github.com/RustCrypto/hashes"
+  }
+}

--- a/tests/fixtures/digest/kats/jh256_abc.json
+++ b/tests/fixtures/digest/kats/jh256_abc.json
@@ -1,0 +1,12 @@
+{
+  "algorithm": "JH256",
+  "input": {
+    "encoding": "utf8",
+    "value": "abc"
+  },
+  "expected_hex": "924bc82f24a76d519d4f69493da7fa70dc88bdb6016b6d1cc1dcf7def15e9cdd",
+  "source": {
+    "title": "JH hash \u2014 SHA-3 competition / RustCrypto jh tests",
+    "url": "https://github.com/RustCrypto/hashes"
+  }
+}

--- a/tests/fixtures/digest/kats/jh384_abc.json
+++ b/tests/fixtures/digest/kats/jh384_abc.json
@@ -1,0 +1,12 @@
+{
+  "algorithm": "JH384",
+  "input": {
+    "encoding": "utf8",
+    "value": "abc"
+  },
+  "expected_hex": "fc41b2b33438dc818a6ef99dd86f2c02a9c42ade5d0d3422f0cdd2289d50b6472c59798e569a0faec4c632e3340d1442",
+  "source": {
+    "title": "JH hash \u2014 SHA-3 competition / RustCrypto jh tests",
+    "url": "https://github.com/RustCrypto/hashes"
+  }
+}

--- a/tests/fixtures/digest/kats/jh512_abc.json
+++ b/tests/fixtures/digest/kats/jh512_abc.json
@@ -1,0 +1,12 @@
+{
+  "algorithm": "JH512",
+  "input": {
+    "encoding": "utf8",
+    "value": "abc"
+  },
+  "expected_hex": "a05eab9c641cb901107d9880bcdf0eedb19b0073188896365921bd200225d9176cf136e7af90d67bdb05dfa3037e48b757d23a905b2270db67255b9eca982973",
+  "source": {
+    "title": "JH hash \u2014 SHA-3 competition / RustCrypto jh tests",
+    "url": "https://github.com/RustCrypto/hashes"
+  }
+}

--- a/tests/fixtures/digest/kats/md2_abc.json
+++ b/tests/fixtures/digest/kats/md2_abc.json
@@ -1,0 +1,12 @@
+{
+  "algorithm": "MD2",
+  "input": {
+    "encoding": "utf8",
+    "value": "abc"
+  },
+  "expected_hex": "da853b0d3f88d99b30283a69e6ded6bb",
+  "source": {
+    "title": "RFC 1319 \u2014 The MD2 Message-Digest Algorithm",
+    "url": "https://www.rfc-editor.org/rfc/rfc1319"
+  }
+}

--- a/tests/fixtures/digest/kats/md4_abc.json
+++ b/tests/fixtures/digest/kats/md4_abc.json
@@ -1,0 +1,12 @@
+{
+  "algorithm": "MD4",
+  "input": {
+    "encoding": "utf8",
+    "value": "abc"
+  },
+  "expected_hex": "a448017aaf21d8525fc10ae87aa6729d",
+  "source": {
+    "title": "RFC 1320 \u2014 The MD4 Message-Digest Algorithm",
+    "url": "https://www.rfc-editor.org/rfc/rfc1320"
+  }
+}

--- a/tests/fixtures/digest/kats/ripemd160_abc.json
+++ b/tests/fixtures/digest/kats/ripemd160_abc.json
@@ -1,0 +1,12 @@
+{
+  "algorithm": "RIPEMD160",
+  "input": {
+    "encoding": "utf8",
+    "value": "abc"
+  },
+  "expected_hex": "8eb208f7e05d987a9b044a8e98c6b087f15a0bfc",
+  "source": {
+    "title": "ISO/IEC 10118-3 RIPEMD-160",
+    "url": "https://www.iso.org/standard/39876.html"
+  }
+}

--- a/tests/fixtures/digest/kats/ripemd320_abc.json
+++ b/tests/fixtures/digest/kats/ripemd320_abc.json
@@ -1,0 +1,12 @@
+{
+  "algorithm": "RIPEMD320",
+  "input": {
+    "encoding": "utf8",
+    "value": "abc"
+  },
+  "expected_hex": "de4c01b3054f8930a79d09ae738e92301e5a17085beffdc1b8d116713e74f82fa942d64cdbc4682d",
+  "source": {
+    "title": "ISO/IEC 10118-3 RIPEMD-320",
+    "url": "https://www.iso.org/standard/39876.html"
+  }
+}

--- a/tests/fixtures/digest/kats/sha224_abc.json
+++ b/tests/fixtures/digest/kats/sha224_abc.json
@@ -1,0 +1,12 @@
+{
+  "algorithm": "SHA224",
+  "input": {
+    "encoding": "utf8",
+    "value": "abc"
+  },
+  "expected_hex": "23097d223405d8228642a477bda255b32aadbce4bda0b3f7e36c9da7",
+  "source": {
+    "title": "FIPS 180-4 \u2014 Secure Hash Standard",
+    "url": "https://doi.org/10.6028/NIST.FIPS.180-4"
+  }
+}

--- a/tests/fixtures/digest/kats/sha384_abc.json
+++ b/tests/fixtures/digest/kats/sha384_abc.json
@@ -1,0 +1,12 @@
+{
+  "algorithm": "SHA384",
+  "input": {
+    "encoding": "utf8",
+    "value": "abc"
+  },
+  "expected_hex": "cb00753f45a35e8bb5a03d699ac65007272c32ab0eded1631a8b605a43ff5bed8086072ba1e7cc2358baeca134c825a7",
+  "source": {
+    "title": "FIPS 180-4 \u2014 Secure Hash Standard",
+    "url": "https://doi.org/10.6028/NIST.FIPS.180-4"
+  }
+}

--- a/tests/fixtures/digest/kats/sha3_224_abc.json
+++ b/tests/fixtures/digest/kats/sha3_224_abc.json
@@ -1,0 +1,12 @@
+{
+  "algorithm": "SHA3_224",
+  "input": {
+    "encoding": "utf8",
+    "value": "abc"
+  },
+  "expected_hex": "e642824c3f8cf24ad09234ee7d3c766fc9a3a5168d0c94ad73b46fdf",
+  "source": {
+    "title": "FIPS 202 \u2014 SHA-3 Standard",
+    "url": "https://doi.org/10.6028/NIST.FIPS.202"
+  }
+}

--- a/tests/fixtures/digest/kats/sha3_256_abc.json
+++ b/tests/fixtures/digest/kats/sha3_256_abc.json
@@ -1,0 +1,12 @@
+{
+  "algorithm": "SHA3_256",
+  "input": {
+    "encoding": "utf8",
+    "value": "abc"
+  },
+  "expected_hex": "3a985da74fe225b2045c172d6bd390bd855f086e3e9d525b46bfe24511431532",
+  "source": {
+    "title": "FIPS 202 \u2014 SHA-3 Standard",
+    "url": "https://doi.org/10.6028/NIST.FIPS.202"
+  }
+}

--- a/tests/fixtures/digest/kats/sha3_384_abc.json
+++ b/tests/fixtures/digest/kats/sha3_384_abc.json
@@ -1,0 +1,12 @@
+{
+  "algorithm": "SHA3_384",
+  "input": {
+    "encoding": "utf8",
+    "value": "abc"
+  },
+  "expected_hex": "ec01498288516fc926459f58e2c6ad8df9b473cb0fc08c2596da7cf0e49be4b298d88cea927ac7f539f1edf228376d25",
+  "source": {
+    "title": "FIPS 202 \u2014 SHA-3 Standard",
+    "url": "https://doi.org/10.6028/NIST.FIPS.202"
+  }
+}

--- a/tests/fixtures/digest/kats/sha3_512_abc.json
+++ b/tests/fixtures/digest/kats/sha3_512_abc.json
@@ -1,0 +1,12 @@
+{
+  "algorithm": "SHA3_512",
+  "input": {
+    "encoding": "utf8",
+    "value": "abc"
+  },
+  "expected_hex": "b751850b1a57168a5693cd924b6b096e08f621827444f70d884f5d0240d2712e10e116e9192af3c91a7ec57647e3934057340b4cf408d5a56592f8274eec53f0",
+  "source": {
+    "title": "FIPS 202 \u2014 SHA-3 Standard",
+    "url": "https://doi.org/10.6028/NIST.FIPS.202"
+  }
+}

--- a/tests/fixtures/digest/kats/sha512_abc.json
+++ b/tests/fixtures/digest/kats/sha512_abc.json
@@ -1,0 +1,12 @@
+{
+  "algorithm": "SHA512",
+  "input": {
+    "encoding": "utf8",
+    "value": "abc"
+  },
+  "expected_hex": "ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f",
+  "source": {
+    "title": "FIPS 180-4 \u2014 Secure Hash Standard",
+    "url": "https://doi.org/10.6028/NIST.FIPS.180-4"
+  }
+}

--- a/tests/fixtures/digest/kats/shabal192_abc.json
+++ b/tests/fixtures/digest/kats/shabal192_abc.json
@@ -1,0 +1,12 @@
+{
+  "algorithm": "SHABAL192",
+  "input": {
+    "encoding": "utf8",
+    "value": "abc"
+  },
+  "expected_hex": "fc0e7b3568c6daef93e7b9a44e83739a75ae2722c6713ce8",
+  "source": {
+    "title": "Shabal \u2014 SHA-3 competition / RustCrypto shabal tests",
+    "url": "https://github.com/RustCrypto/hashes"
+  }
+}

--- a/tests/fixtures/digest/kats/shabal224_abc.json
+++ b/tests/fixtures/digest/kats/shabal224_abc.json
@@ -1,0 +1,12 @@
+{
+  "algorithm": "SHABAL224",
+  "input": {
+    "encoding": "utf8",
+    "value": "abc"
+  },
+  "expected_hex": "f47578239607af492d5f7df9241818adf6fba4180ddcbef6e39ac1e9",
+  "source": {
+    "title": "Shabal \u2014 SHA-3 competition / RustCrypto shabal tests",
+    "url": "https://github.com/RustCrypto/hashes"
+  }
+}

--- a/tests/fixtures/digest/kats/shabal256_abc.json
+++ b/tests/fixtures/digest/kats/shabal256_abc.json
@@ -1,0 +1,12 @@
+{
+  "algorithm": "SHABAL256",
+  "input": {
+    "encoding": "utf8",
+    "value": "abc"
+  },
+  "expected_hex": "07225fab83ca48fb480d22219410d5ca008359efbfd315829029afe2cb3f0404",
+  "source": {
+    "title": "Shabal \u2014 SHA-3 competition / RustCrypto shabal tests",
+    "url": "https://github.com/RustCrypto/hashes"
+  }
+}

--- a/tests/fixtures/digest/kats/shabal384_abc.json
+++ b/tests/fixtures/digest/kats/shabal384_abc.json
@@ -1,0 +1,12 @@
+{
+  "algorithm": "SHABAL384",
+  "input": {
+    "encoding": "utf8",
+    "value": "abc"
+  },
+  "expected_hex": "66613058865271722c0295774aa77258a5082bebbb5a02f9d6aee9ad303fc71cbf19e2f599ddfde88cf0bf30a028e530",
+  "source": {
+    "title": "Shabal \u2014 SHA-3 competition / RustCrypto shabal tests",
+    "url": "https://github.com/RustCrypto/hashes"
+  }
+}

--- a/tests/fixtures/digest/kats/shabal512_abc.json
+++ b/tests/fixtures/digest/kats/shabal512_abc.json
@@ -1,0 +1,12 @@
+{
+  "algorithm": "SHABAL512",
+  "input": {
+    "encoding": "utf8",
+    "value": "abc"
+  },
+  "expected_hex": "4a7f0f707c1b0c1d12ddcfa8aa0f9d2410dd9bab57c2d56705fc1acb02066f99678738cedb20a2aba94842a441e77bc02656fe5690f98b421d029bfc4df09f91",
+  "source": {
+    "title": "Shabal \u2014 SHA-3 competition / RustCrypto shabal tests",
+    "url": "https://github.com/RustCrypto/hashes"
+  }
+}

--- a/tests/fixtures/digest/kats/skein1024_abc.json
+++ b/tests/fixtures/digest/kats/skein1024_abc.json
@@ -1,0 +1,12 @@
+{
+  "algorithm": "SKEIN1024",
+  "input": {
+    "encoding": "utf8",
+    "value": "abc"
+  },
+  "expected_hex": "35a599a0f91abcdb4cb73c19b8cb8d947742d82c309137a7caed29e8e0a2ca7a9ff9a90c34c1908cc7e7fd99bb15032fb86e76df21b72628399b5f7c3cc209d7bb31c99cd4e19465622a049afbb87c03b5ce3888d17e6e667279ec0aa9b3e2712624c01b5f5bbe1a564220bdcf6990af0c2539019f313fdd7406cca3892a1f1f",
+  "source": {
+    "title": "Skein 1.3 \u2014 Skein-1024-1024 known-answer tests",
+    "url": "https://www.schneier.com/academic/skein/"
+  }
+}

--- a/tests/fixtures/digest/kats/skein256_abc.json
+++ b/tests/fixtures/digest/kats/skein256_abc.json
@@ -1,0 +1,12 @@
+{
+  "algorithm": "SKEIN256",
+  "input": {
+    "encoding": "utf8",
+    "value": "abc"
+  },
+  "expected_hex": "258bdec343b9fde1639221a5ae0144a96e552e5288753c5fec76c05fc2fc1870",
+  "source": {
+    "title": "Skein 1.3 \u2014 Skein-256-256 known-answer tests",
+    "url": "https://www.schneier.com/academic/skein/"
+  }
+}

--- a/tests/fixtures/digest/kats/skein512_abc.json
+++ b/tests/fixtures/digest/kats/skein512_abc.json
@@ -1,0 +1,12 @@
+{
+  "algorithm": "SKEIN512",
+  "input": {
+    "encoding": "utf8",
+    "value": "abc"
+  },
+  "expected_hex": "8f5dd9ec798152668e35129496b029a960c9a9b88662f7f9482f110b31f9f93893ecfb25c009baad9e46737197d5630379816a886aa05526d3a70df272d96e75",
+  "source": {
+    "title": "Skein 1.3 \u2014 Skein-512-512 known-answer tests",
+    "url": "https://www.schneier.com/academic/skein/"
+  }
+}

--- a/tests/fixtures/digest/kats/sm3_abc.json
+++ b/tests/fixtures/digest/kats/sm3_abc.json
@@ -1,0 +1,12 @@
+{
+  "algorithm": "SM3",
+  "input": {
+    "encoding": "utf8",
+    "value": "abc"
+  },
+  "expected_hex": "66c7f0f462eeedd9d1f2d46bdc10e4e24167c4875cf2f7a2297da02b8f4ba8e0",
+  "source": {
+    "title": "GM/T 0004-2012 SM3",
+    "url": "https://www.oscca.gov.cn/"
+  }
+}

--- a/tests/fixtures/digest/kats/snefru256_abc.json
+++ b/tests/fixtures/digest/kats/snefru256_abc.json
@@ -1,0 +1,12 @@
+{
+  "algorithm": "SNEFRU256",
+  "input": {
+    "encoding": "utf8",
+    "value": "abc"
+  },
+  "expected_hex": "7d033205647a2af3dc8339f6cb25643c33ebc622d32979c4b612b02c4903031b",
+  "source": {
+    "title": "Snefru (Merkle) \u2014 8-pass digests",
+    "url": "https://en.wikipedia.org/wiki/Snefru"
+  }
+}

--- a/tests/fixtures/digest/kats/streebog256_abc.json
+++ b/tests/fixtures/digest/kats/streebog256_abc.json
@@ -1,0 +1,12 @@
+{
+  "algorithm": "STREEBOG256",
+  "input": {
+    "encoding": "utf8",
+    "value": "abc"
+  },
+  "expected_hex": "4e2919cf137ed41ec4fb6270c61826cc4fffb660341e0af3688cd0626d23b481",
+  "source": {
+    "title": "GOST R 34.11-2012 Streebog-256 / gost-engine etalon",
+    "url": "https://github.com/gost-engine/engine"
+  }
+}

--- a/tests/fixtures/digest/kats/streebog512_abc.json
+++ b/tests/fixtures/digest/kats/streebog512_abc.json
@@ -1,0 +1,12 @@
+{
+  "algorithm": "STREEBOG512",
+  "input": {
+    "encoding": "utf8",
+    "value": "abc"
+  },
+  "expected_hex": "28156e28317da7c98f4fe2bed6b542d0dab85bb224445fcedaf75d46e26d7eb8d5997f3e0915dd6b7f0aab08d9c8beb0d8c64bae2ab8b3c8c6bc53b3bf0db728",
+  "source": {
+    "title": "GOST R 34.11-2012 Streebog-512 / gost-engine etalon",
+    "url": "https://github.com/gost-engine/engine"
+  }
+}

--- a/tests/fixtures/digest/kats/tiger_abc.json
+++ b/tests/fixtures/digest/kats/tiger_abc.json
@@ -1,0 +1,12 @@
+{
+  "algorithm": "TIGER",
+  "input": {
+    "encoding": "utf8",
+    "value": "abc"
+  },
+  "expected_hex": "2aab1484e8c158f2bfb8c5ff41b57a525129131c957b5f93",
+  "source": {
+    "title": "Tiger hash function \u2014 Anderson & Biham",
+    "url": "https://www.cs.technion.ac.il/~biham/Reports/Tiger/"
+  }
+}

--- a/tests/fixtures/digest/kats/whirlpool_abc.json
+++ b/tests/fixtures/digest/kats/whirlpool_abc.json
@@ -1,0 +1,12 @@
+{
+  "algorithm": "WHIRLPOOL",
+  "input": {
+    "encoding": "utf8",
+    "value": "abc"
+  },
+  "expected_hex": "4e2448a4c6f486bb16b6562c73b4020bf3043e3a731bce721ae1b303d97e6d4c7181eebdb6c57e277d0e34957114cbd6c797fc9d95d8b582d225292076d4eef5",
+  "source": {
+    "title": "ISO/IEC 10118-3 Whirlpool",
+    "url": "https://www.iso.org/standard/39876.html"
+  }
+}

--- a/tests/fixtures/interactive/console_color_auto.txt
+++ b/tests/fixtures/interactive/console_color_auto.txt
@@ -9,7 +9,7 @@ Arguments:
 
 Options:
   -a, --algorithm <algorithm>
-          Digest algorithm identifier (e.g., sha256). ⚠ Weak: MD5, SHA-1, SHA-224 (md5, sha1, sha224). See README section "Weak Digest Algorithms" for safer alternatives.
+          Digest algorithm identifier (e.g., sha256). ⚠ Weak: MD5, SHA-1, SHA-224, Snefru-128, Snefru-256 (md5, sha1, sha224, snefru, snefru128, snefru256). See README section "Weak Digest Algorithms" for safer alternatives.
 
   -f, --format <format>
           Output format (json, jsonl, csv, hex, base64, hashcat, multihash=base58btc)

--- a/tests/fixtures/interactive/console_help_digest.txt
+++ b/tests/fixtures/interactive/console_help_digest.txt
@@ -9,7 +9,7 @@ Arguments:
 
 Options:
   -a, --algorithm <algorithm>
-          Digest algorithm identifier (e.g., sha256). ⚠ Weak: MD5, SHA-1, SHA-224 (md5, sha1, sha224). See README section "Weak Digest Algorithms" for safer alternatives.
+          Digest algorithm identifier (e.g., sha256). ⚠ Weak: MD5, SHA-1, SHA-224, Snefru-128, Snefru-256 (md5, sha1, sha224, snefru, snefru128, snefru256). See README section "Weak Digest Algorithms" for safer alternatives.
 
   -f, --format <format>
           Output format (json, jsonl, csv, hex, base64, hashcat, multihash=base58btc)

--- a/tests/fixtures/kdf/README.md
+++ b/tests/fixtures/kdf/README.md
@@ -10,3 +10,7 @@ Canonical fixtures for `rgh kdf` commands. Include parameter sets (memory, time,
 - `kdf_scrypt_profile_owasp.json`: scrypt derived key based on OWASP 2024 recommended parameters.
 - `kdf_pbkdf2_invalid_iterations.json`: PBKDF2 preset violation expecting exit code `2` with NIST SP 800-132 guidance.
 - `kdf_scrypt_zero_password.json`: Scrypt invocation with zero-length secret; aborts with exit code `2` and password validation error.
+
+## Known-answer tests (`kats/`)
+
+Sourced fixed-parameter vectors for every ID in `KDF_ALGORITHM_IDS`. Password KDFs use deterministic salts; HKDF vectors reuse or mirror the audit fixtures. Coverage is gated by `tests/kdf_kats.rs`.

--- a/tests/fixtures/kdf/kats/argon2.json
+++ b/tests/fixtures/kdf/kats/argon2.json
@@ -1,0 +1,21 @@
+{
+  "algorithm": "argon2",
+  "password": {
+    "encoding": "utf8",
+    "value": "password"
+  },
+  "salt": {
+    "encoding": "hex",
+    "value": "00112233445566778899aabbccddeeff"
+  },
+  "params": {
+    "mem_cost": 4096,
+    "time_cost": 1,
+    "parallelism": 1
+  },
+  "expected": "$argon2id$v=19$m=4096,t=1,p=1$ABEiM0RVZneImaq7zN3u/w$/wclL8iqozQ+VkrwMd0Xrwc37ScVjeFbYStJlPDKJhM",
+  "source": {
+    "title": "Argon2id PHC string \u2014 fixed-parameter rgh KAT (RFC 9106 parameters subset)",
+    "url": "https://www.rfc-editor.org/rfc/rfc9106"
+  }
+}

--- a/tests/fixtures/kdf/kats/balloon.json
+++ b/tests/fixtures/kdf/kats/balloon.json
@@ -1,0 +1,21 @@
+{
+  "algorithm": "balloon",
+  "password": {
+    "encoding": "utf8",
+    "value": "password"
+  },
+  "salt": {
+    "encoding": "hex",
+    "value": "00112233445566778899aabbccddeeff"
+  },
+  "params": {
+    "time_cost": 1,
+    "memory_cost": 1024,
+    "parallelism": 1
+  },
+  "expected": "$balloon$v=1$s=1,t=1024,p=1$ABEiM0RVZneImaq7zN3u/w$GZNP4EXeos6C6rdSCVEzbKOfiIKdLUm/TRaT2PKOFRk",
+  "source": {
+    "title": "Balloon hashing \u2014 fixed-parameter rgh KAT",
+    "url": "https://eprint.iacr.org/2016/027"
+  }
+}

--- a/tests/fixtures/kdf/kats/bcrypt.json
+++ b/tests/fixtures/kdf/kats/bcrypt.json
@@ -1,0 +1,19 @@
+{
+  "algorithm": "bcrypt",
+  "password": {
+    "encoding": "utf8",
+    "value": "password"
+  },
+  "salt": {
+    "encoding": "hex",
+    "value": "00112233445566778899aabbccddeeff"
+  },
+  "params": {
+    "cost": 4
+  },
+  "expected": "b0d41a2981c57eb1a8d77de50c41b7a9911f6db6376242a3b6902697ac0d64a45466f6cf5ee380cd2d0dc7bbbddc8f9766a6fb6399ef57d50a719d005c7eb3aa",
+  "source": {
+    "title": "bcrypt_pbkdf (OpenSSH) \u2014 fixed-parameter rgh KAT",
+    "url": "https://docs.rs/bcrypt-pbkdf"
+  }
+}

--- a/tests/fixtures/kdf/kats/hkdf_blake3.json
+++ b/tests/fixtures/kdf/kats/hkdf_blake3.json
@@ -1,0 +1,23 @@
+{
+  "algorithm": "hkdf-blake3",
+  "ikm": {
+    "encoding": "hex",
+    "value": "696b6d"
+  },
+  "salt": {
+    "encoding": "hex",
+    "value": "73616c74"
+  },
+  "info": {
+    "encoding": "hex",
+    "value": "696e666f"
+  },
+  "params": {
+    "length": 32
+  },
+  "expected": "75fc4de76f10493c7e6dfa25aac2a1ec108dd5b0517919fd79cfff8e50431b5b",
+  "source": {
+    "title": "BLAKE3 keyed / HKDF-style extract-expand \u2014 rgh audit fixture",
+    "url": "https://github.com/BLAKE3-team/BLAKE3/blob/master/blake3.pdf"
+  }
+}

--- a/tests/fixtures/kdf/kats/hkdf_sha256.json
+++ b/tests/fixtures/kdf/kats/hkdf_sha256.json
@@ -1,0 +1,23 @@
+{
+  "algorithm": "hkdf-sha256",
+  "ikm": {
+    "encoding": "hex",
+    "value": "726f6f7420736563726574"
+  },
+  "salt": {
+    "encoding": "hex",
+    "value": "73616c74"
+  },
+  "info": {
+    "encoding": "hex",
+    "value": "617069"
+  },
+  "params": {
+    "length": 32
+  },
+  "expected": "33f4df5eeadc1255748856f1f3c81be1e8cfd58e55a7f61e5abb729c279e922b",
+  "source": {
+    "title": "RFC 5869 HKDF-SHA256 \u2014 rgh audit fixture kdf_hkdf_sha256_basic",
+    "url": "https://www.rfc-editor.org/rfc/rfc5869"
+  }
+}

--- a/tests/fixtures/kdf/kats/hkdf_sha3_256.json
+++ b/tests/fixtures/kdf/kats/hkdf_sha3_256.json
@@ -1,0 +1,23 @@
+{
+  "algorithm": "hkdf-sha3-256",
+  "ikm": {
+    "encoding": "hex",
+    "value": "696b6d"
+  },
+  "salt": {
+    "encoding": "hex",
+    "value": "73616c74"
+  },
+  "info": {
+    "encoding": "hex",
+    "value": "696e666f"
+  },
+  "params": {
+    "length": 32
+  },
+  "expected": "0a35ce133619c6dda6c47247ba3a65352b8fa7313a3ccddfc707ea425085517c",
+  "source": {
+    "title": "HKDF with SHA3-256 (RFC 5869 construction) \u2014 fixed-parameter rgh KAT",
+    "url": "https://www.rfc-editor.org/rfc/rfc5869"
+  }
+}

--- a/tests/fixtures/kdf/kats/hkdf_sha3_512.json
+++ b/tests/fixtures/kdf/kats/hkdf_sha3_512.json
@@ -1,0 +1,23 @@
+{
+  "algorithm": "hkdf-sha3-512",
+  "ikm": {
+    "encoding": "hex",
+    "value": "696b6d"
+  },
+  "salt": {
+    "encoding": "hex",
+    "value": "73616c74"
+  },
+  "info": {
+    "encoding": "hex",
+    "value": "696e666f"
+  },
+  "params": {
+    "length": 64
+  },
+  "expected": "6829b2bdf3102d20161f7f54e204bddcd0397391be5b32a818770ec7e96c714e6448e84030c0efa2f22d520c9a6bf459f91365904114e0ec00dd866fa734b1f4",
+  "source": {
+    "title": "HKDF with SHA3-512 (RFC 5869 construction) \u2014 fixed-parameter rgh KAT",
+    "url": "https://www.rfc-editor.org/rfc/rfc5869"
+  }
+}

--- a/tests/fixtures/kdf/kats/hkdf_sha512.json
+++ b/tests/fixtures/kdf/kats/hkdf_sha512.json
@@ -1,0 +1,23 @@
+{
+  "algorithm": "hkdf-sha512",
+  "ikm": {
+    "encoding": "hex",
+    "value": "657069736f6465206f6e65"
+  },
+  "salt": {
+    "encoding": "hex",
+    "value": "00010203040506070809"
+  },
+  "info": {
+    "encoding": "hex",
+    "value": "f0f1f2f3f4f5"
+  },
+  "params": {
+    "length": 64
+  },
+  "expected": "943c37403843d95e20c2bdf15de11fed18a9a31a2a6b57b1c7ede559ba4e3abb8656a5770650e155cdade5e4d63f57c816a1c9e01de37cc1190e69de7d59d3f6",
+  "source": {
+    "title": "RFC 5869 HKDF-SHA512 \u2014 rgh audit fixture kdf_hkdf_sha512_info",
+    "url": "https://www.rfc-editor.org/rfc/rfc5869"
+  }
+}

--- a/tests/fixtures/kdf/kats/pbkdf2_sha256.json
+++ b/tests/fixtures/kdf/kats/pbkdf2_sha256.json
@@ -1,0 +1,20 @@
+{
+  "algorithm": "pbkdf2-sha256",
+  "password": {
+    "encoding": "utf8",
+    "value": "password"
+  },
+  "salt": {
+    "encoding": "hex",
+    "value": "00112233445566778899aabbccddeeff"
+  },
+  "params": {
+    "rounds": 1000,
+    "output_length": 32
+  },
+  "expected": "$pbkdf2-sha256$i=1000,l=32$ABEiM0RVZneImaq7zN3u/w$btIUe5tnBiQnWoqxV1lSTKBi2Jkqra5qCDtLwUjRICc",
+  "source": {
+    "title": "RFC 8018 PBKDF2-HMAC-SHA256 \u2014 fixed-parameter rgh KAT",
+    "url": "https://www.rfc-editor.org/rfc/rfc8018"
+  }
+}

--- a/tests/fixtures/kdf/kats/pbkdf2_sha512.json
+++ b/tests/fixtures/kdf/kats/pbkdf2_sha512.json
@@ -1,0 +1,20 @@
+{
+  "algorithm": "pbkdf2-sha512",
+  "password": {
+    "encoding": "utf8",
+    "value": "password"
+  },
+  "salt": {
+    "encoding": "hex",
+    "value": "00112233445566778899aabbccddeeff"
+  },
+  "params": {
+    "rounds": 1000,
+    "output_length": 64
+  },
+  "expected": "$pbkdf2-sha512$i=1000,l=64$ABEiM0RVZneImaq7zN3u/w$0jkEYnJIcOam/amkudeWZusvjfYfCxIhbOKPbcTW3KF8v/m8GZVUvStHV+vV5R8zZVFCEXvhO7DTh32vNDzVow",
+  "source": {
+    "title": "RFC 8018 PBKDF2-HMAC-SHA512 \u2014 fixed-parameter rgh KAT",
+    "url": "https://www.rfc-editor.org/rfc/rfc8018"
+  }
+}

--- a/tests/fixtures/kdf/kats/scrypt.json
+++ b/tests/fixtures/kdf/kats/scrypt.json
@@ -1,0 +1,21 @@
+{
+  "algorithm": "scrypt",
+  "password": {
+    "encoding": "utf8",
+    "value": "password"
+  },
+  "salt": {
+    "encoding": "hex",
+    "value": "00112233445566778899aabbccddeeff"
+  },
+  "params": {
+    "log_n": 14,
+    "r": 8,
+    "p": 1
+  },
+  "expected": "$scrypt$ln=14,r=8,p=1$ABEiM0RVZneImaq7zN3u/w$VdHILC47vYMggNVoOPTInR5yRTHxB32oZg+9LTjbYpU",
+  "source": {
+    "title": "RFC 7914 scrypt \u2014 fixed-parameter rgh KAT",
+    "url": "https://www.rfc-editor.org/rfc/rfc7914"
+  }
+}

--- a/tests/fixtures/kdf/kats/sha_crypt.json
+++ b/tests/fixtures/kdf/kats/sha_crypt.json
@@ -1,0 +1,19 @@
+{
+  "algorithm": "sha-crypt",
+  "password": {
+    "encoding": "utf8",
+    "value": "password"
+  },
+  "salt": {
+    "encoding": "hex",
+    "value": "00112233445566778899aabbccddeeff"
+  },
+  "params": {
+    "rounds": 10000
+  },
+  "expected": "$6$rounds=10000$.2V6nEIJaR5WNeuiArhvz1$n6q7nVVcmPoiyH97mZ/EQGnO6Br6P46EZynkI9wVQbP6s.jDfV8qntGW3QcgxTzKR1.so/Sok.IKWrWhwxMd8.",
+  "source": {
+    "title": "Unix sha512-crypt (glibc) \u2014 fixed-parameter rgh KAT",
+    "url": "https://www.akkadia.org/drepper/SHA-crypt.txt"
+  }
+}

--- a/tests/fixtures/mac/README.md
+++ b/tests/fixtures/mac/README.md
@@ -13,3 +13,7 @@ Add new fixtures alongside published test vectors to ensure deterministic regres
 Recent additions:
 - `mac_poly1305_mismatched_key.json`: Verifies oversized Poly1305 keys exit with RFC 8439 guidance and exit code `2`.
 - `mac_cmac_padding_mismatch.json`: Validates CMAC key length enforcement (invalid 12-byte key) with exit code `2` and actionable error text.
+
+## Known-answer tests (`kats/`)
+
+Every algorithm from `mac::registry::algorithms()` must have a JSON file under `kats/` with `algorithm`, `key.path`, `input`, `expected_hex`, and `source`. Coverage is enforced by `tests/mac_kats.rs`.

--- a/tests/fixtures/mac/kats/blake3_keyed.json
+++ b/tests/fixtures/mac/kats/blake3_keyed.json
@@ -1,0 +1,15 @@
+{
+  "algorithm": "blake3-keyed",
+  "key": {
+    "path": "tests/fixtures/keys/blake3.key"
+  },
+  "input": {
+    "encoding": "utf8",
+    "value": "alpha"
+  },
+  "expected_hex": "e66e5af037fb22dc6d957057b669507d4627de61b43061053cb3782ecb07e41f",
+  "source": {
+    "title": "BLAKE3 keyed mode \u00a75",
+    "url": "https://github.com/BLAKE3-team/BLAKE3-specs"
+  }
+}

--- a/tests/fixtures/mac/kats/cmac_aes128.json
+++ b/tests/fixtures/mac/kats/cmac_aes128.json
@@ -1,0 +1,15 @@
+{
+  "algorithm": "cmac-aes128",
+  "key": {
+    "path": "tests/fixtures/keys/cmac_aes128.key"
+  },
+  "input": {
+    "encoding": "utf8",
+    "value": "compliance-mac"
+  },
+  "expected_hex": "3d5db00e9962fadb33cf8153f3167dae",
+  "source": {
+    "title": "NIST SP 800-38B AES-CMAC",
+    "url": "https://doi.org/10.6028/NIST.SP.800-38B"
+  }
+}

--- a/tests/fixtures/mac/kats/cmac_aes192.json
+++ b/tests/fixtures/mac/kats/cmac_aes192.json
@@ -1,0 +1,15 @@
+{
+  "algorithm": "cmac-aes192",
+  "key": {
+    "path": "tests/fixtures/keys/cmac_aes192.key"
+  },
+  "input": {
+    "encoding": "utf8",
+    "value": "compliance-mac"
+  },
+  "expected_hex": "38065813c1b59fcb7426ddad57d59623",
+  "source": {
+    "title": "NIST SP 800-38B AES-CMAC",
+    "url": "https://doi.org/10.6028/NIST.SP.800-38B"
+  }
+}

--- a/tests/fixtures/mac/kats/cmac_aes256.json
+++ b/tests/fixtures/mac/kats/cmac_aes256.json
@@ -1,0 +1,15 @@
+{
+  "algorithm": "cmac-aes256",
+  "key": {
+    "path": "tests/fixtures/keys/cmac_aes256.key"
+  },
+  "input": {
+    "encoding": "utf8",
+    "value": "compliance-mac"
+  },
+  "expected_hex": "2c8aa06bc8e0b8e8cc67b56db667d884",
+  "source": {
+    "title": "NIST SP 800-38B AES-CMAC",
+    "url": "https://doi.org/10.6028/NIST.SP.800-38B"
+  }
+}

--- a/tests/fixtures/mac/kats/hmac_sha1.json
+++ b/tests/fixtures/mac/kats/hmac_sha1.json
@@ -1,0 +1,15 @@
+{
+  "algorithm": "hmac-sha1",
+  "key": {
+    "path": "tests/fixtures/keys/hmac.key"
+  },
+  "input": {
+    "encoding": "utf8",
+    "value": "alpha"
+  },
+  "expected_hex": "23ea5cec55f20f94385951e634a461e26c2554f3",
+  "source": {
+    "title": "RFC 2104 / NIST SP 800-131A (legacy HMAC-SHA1)",
+    "url": "https://www.rfc-editor.org/rfc/rfc2104"
+  }
+}

--- a/tests/fixtures/mac/kats/hmac_sha256.json
+++ b/tests/fixtures/mac/kats/hmac_sha256.json
@@ -1,0 +1,15 @@
+{
+  "algorithm": "hmac-sha256",
+  "key": {
+    "path": "tests/fixtures/keys/hmac.key"
+  },
+  "input": {
+    "encoding": "utf8",
+    "value": "alpha"
+  },
+  "expected_hex": "36bb6808df1ed0834db71b4d5c671ce1ef3beed1d90ed57ea5362c8a023c9488",
+  "source": {
+    "title": "RFC 2104 with FIPS 180-4 SHA-256",
+    "url": "https://www.rfc-editor.org/rfc/rfc2104"
+  }
+}

--- a/tests/fixtures/mac/kats/hmac_sha3_256.json
+++ b/tests/fixtures/mac/kats/hmac_sha3_256.json
@@ -1,0 +1,15 @@
+{
+  "algorithm": "hmac-sha3-256",
+  "key": {
+    "path": "tests/fixtures/keys/hmac.key"
+  },
+  "input": {
+    "encoding": "utf8",
+    "value": "alpha"
+  },
+  "expected_hex": "a53c80426d66d10b971a224fe5528d1a83103092aba88deb0b53fb0d8c5a04f1",
+  "source": {
+    "title": "RFC 2104 with FIPS 202 SHA3-256",
+    "url": "https://doi.org/10.6028/NIST.FIPS.202"
+  }
+}

--- a/tests/fixtures/mac/kats/hmac_sha3_512.json
+++ b/tests/fixtures/mac/kats/hmac_sha3_512.json
@@ -1,0 +1,15 @@
+{
+  "algorithm": "hmac-sha3-512",
+  "key": {
+    "path": "tests/fixtures/keys/hmac.key"
+  },
+  "input": {
+    "encoding": "utf8",
+    "value": "alpha"
+  },
+  "expected_hex": "e6b1a15f133580e98567da53ae24c954ae9e295a9fd65bc3438414a40ca36cda1beaf8923c5cbc61dcebebdfb203e40501ee83bb685567c2816b84c6f990bdc2",
+  "source": {
+    "title": "RFC 2104 with FIPS 202 SHA3-512",
+    "url": "https://doi.org/10.6028/NIST.FIPS.202"
+  }
+}

--- a/tests/fixtures/mac/kats/hmac_sha512.json
+++ b/tests/fixtures/mac/kats/hmac_sha512.json
@@ -1,0 +1,15 @@
+{
+  "algorithm": "hmac-sha512",
+  "key": {
+    "path": "tests/fixtures/keys/hmac.key"
+  },
+  "input": {
+    "encoding": "utf8",
+    "value": "alpha"
+  },
+  "expected_hex": "22dc173ba3f0fdc5e2aa8ff463e1158a5f9e78679925b46b0f876825f4bafc35dd5fbc6cce7f0c7be3d2fb38015e7279ce66bc094d1c9e76483c997f078c8666",
+  "source": {
+    "title": "RFC 2104 with FIPS 180-4 SHA-512",
+    "url": "https://www.rfc-editor.org/rfc/rfc2104"
+  }
+}

--- a/tests/fixtures/mac/kats/kmac128.json
+++ b/tests/fixtures/mac/kats/kmac128.json
@@ -1,0 +1,15 @@
+{
+  "algorithm": "kmac128",
+  "key": {
+    "path": "tests/fixtures/keys/kmac.key"
+  },
+  "input": {
+    "encoding": "utf8",
+    "value": "Compliance message"
+  },
+  "expected_hex": "19f1e1d5067f565b7260771084aa26128f68041fa9e95b8d3f41ad1e228f7cfc",
+  "source": {
+    "title": "NIST SP 800-185 KMAC128",
+    "url": "https://doi.org/10.6028/NIST.SP.800-185"
+  }
+}

--- a/tests/fixtures/mac/kats/kmac256.json
+++ b/tests/fixtures/mac/kats/kmac256.json
@@ -1,0 +1,15 @@
+{
+  "algorithm": "kmac256",
+  "key": {
+    "path": "tests/fixtures/keys/kmac.key"
+  },
+  "input": {
+    "encoding": "utf8",
+    "value": "Compliance message"
+  },
+  "expected_hex": "dbbfeb5afc0ace13d06ac2efc2efed874793bd88f2e03f66ae69274bdeaa9c968a63e0259791e2f596c442719e6069cd49f8add11f2cefae6a0f4a7c9c8bd23c",
+  "source": {
+    "title": "NIST SP 800-185 KMAC256",
+    "url": "https://doi.org/10.6028/NIST.SP.800-185"
+  }
+}

--- a/tests/fixtures/mac/kats/poly1305.json
+++ b/tests/fixtures/mac/kats/poly1305.json
@@ -1,0 +1,15 @@
+{
+  "algorithm": "poly1305",
+  "key": {
+    "path": "tests/fixtures/keys/poly1305.key"
+  },
+  "input": {
+    "encoding": "utf8",
+    "value": "config"
+  },
+  "expected_hex": "1cb7a97202776f414eae3333aefc9f57",
+  "source": {
+    "title": "RFC 8439 \u00a72.5 Poly1305",
+    "url": "https://www.rfc-editor.org/rfc/rfc8439"
+  }
+}

--- a/tests/interactive_console.rs
+++ b/tests/interactive_console.rs
@@ -4,6 +4,8 @@
 // Author: Volker Schwaberow <volker@schwaberow.de>
 // Copyright (c) 2022 Volker Schwaberow
 
+#![cfg(not(target_os = "windows"))]
+
 use assert_cmd::prelude::*;
 use predicates::prelude::*;
 use rustgenhash::rgh::console::{

--- a/tests/kdf_kats.rs
+++ b/tests/kdf_kats.rs
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Project: rustgenhash
+
+use base64::{engine::general_purpose::STANDARD_NO_PAD, Engine};
+use rustgenhash::rgh::hash::{
+	Argon2Config, BalloonConfig, BcryptConfig, PHash, Pbkdf2Config,
+	ScryptConfig,
+};
+use rustgenhash::rgh::kdf::hkdf::{
+	derive, HkdfAlgorithm, HkdfInput, HkdfMode, HkdfRequest, HkdfVariant,
+};
+use rustgenhash::rgh::kdf::{SecretMaterial, KDF_ALGORITHM_IDS};
+use serde::Deserialize;
+use std::collections::HashSet;
+use std::fs;
+use std::path::PathBuf;
+use std::str::FromStr;
+
+#[derive(Debug, Deserialize)]
+struct KatSource {
+	title: String,
+	url: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct KatBytes {
+	encoding: String,
+	value: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct KatParams {
+	mem_cost: Option<u32>,
+	time_cost: Option<u32>,
+	parallelism: Option<u32>,
+	log_n: Option<u8>,
+	r: Option<u32>,
+	p: Option<u32>,
+	cost: Option<u32>,
+	rounds: Option<u32>,
+	output_length: Option<usize>,
+	memory_cost: Option<u32>,
+	length: Option<usize>,
+}
+
+#[derive(Debug, Deserialize)]
+struct KatFixture {
+	algorithm: String,
+	password: Option<KatBytes>,
+	salt: Option<KatBytes>,
+	ikm: Option<KatBytes>,
+	info: Option<KatBytes>,
+	params: Option<KatParams>,
+	expected: String,
+	source: KatSource,
+}
+
+fn kats_dir() -> PathBuf {
+	PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/kdf/kats")
+}
+
+fn load_fixtures() -> Vec<(PathBuf, KatFixture)> {
+	let mut entries = Vec::new();
+	for entry in fs::read_dir(kats_dir()).expect("kdf kats directory") {
+		let entry = entry.expect("dir entry");
+		let path = entry.path();
+		if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+			continue;
+		}
+		let raw = fs::read_to_string(&path).unwrap_or_else(|err| {
+			panic!("read {}: {err}", path.display());
+		});
+		let fixture: KatFixture = serde_json::from_str(&raw).unwrap_or_else(|err| {
+			panic!("parse {}: {err}", path.display());
+		});
+		assert!(
+			!fixture.source.title.is_empty() && !fixture.source.url.is_empty(),
+			"{} missing source citation",
+			path.display()
+		);
+		entries.push((path, fixture));
+	}
+	entries.sort_by(|a, b| a.0.cmp(&b.0));
+	assert!(!entries.is_empty(), "no KDF KAT fixtures found");
+	entries
+}
+
+fn decode_bytes(label: &str, input: &KatBytes) -> Vec<u8> {
+	match input.encoding.as_str() {
+		"utf8" => input.value.as_bytes().to_vec(),
+		"hex" => hex::decode(&input.value)
+			.unwrap_or_else(|err| panic!("{label} hex: {err}")),
+		other => panic!("unsupported {label} encoding `{other}`"),
+	}
+}
+
+fn salt_b64(salt: &KatBytes) -> String {
+	STANDARD_NO_PAD.encode(decode_bytes("salt", salt))
+}
+
+fn password_str(password: &KatBytes) -> String {
+	String::from_utf8(decode_bytes("password", password))
+		.expect("password utf8")
+}
+
+fn derive_kat(fixture: &KatFixture) -> String {
+	let params = fixture.params.as_ref();
+	match fixture.algorithm.as_str() {
+		"argon2" => PHash::hash_argon2_with_salt(
+			&password_str(fixture.password.as_ref().expect("password")),
+			&Argon2Config {
+				mem_cost: params.and_then(|p| p.mem_cost).unwrap_or(4096),
+				time_cost: params.and_then(|p| p.time_cost).unwrap_or(1),
+				parallelism: params.and_then(|p| p.parallelism).unwrap_or(1),
+			},
+			&salt_b64(fixture.salt.as_ref().expect("salt")),
+		)
+		.expect("argon2"),
+		"scrypt" => PHash::hash_scrypt_with_salt(
+			&password_str(fixture.password.as_ref().expect("password")),
+			&ScryptConfig {
+				log_n: params.and_then(|p| p.log_n).unwrap_or(14),
+				r: params.and_then(|p| p.r).unwrap_or(8),
+				p: params.and_then(|p| p.p).unwrap_or(1),
+			},
+			&salt_b64(fixture.salt.as_ref().expect("salt")),
+		)
+		.expect("scrypt"),
+		"bcrypt" => PHash::hash_bcrypt_with_salt(
+			&password_str(fixture.password.as_ref().expect("password")),
+			&BcryptConfig {
+				cost: params.and_then(|p| p.cost).unwrap_or(4),
+			},
+			&salt_b64(fixture.salt.as_ref().expect("salt")),
+		)
+		.expect("bcrypt"),
+		"balloon" => PHash::hash_balloon_with_salt(
+			&password_str(fixture.password.as_ref().expect("password")),
+			&BalloonConfig {
+				time_cost: params.and_then(|p| p.time_cost).unwrap_or(1),
+				memory_cost: params.and_then(|p| p.memory_cost).unwrap_or(1024),
+				parallelism: params.and_then(|p| p.parallelism).unwrap_or(1),
+			},
+			&salt_b64(fixture.salt.as_ref().expect("salt")),
+		)
+		.expect("balloon"),
+		"pbkdf2-sha256" => PHash::hash_pbkdf2_with_salt(
+			&password_str(fixture.password.as_ref().expect("password")),
+			"pbkdf2sha256",
+			&Pbkdf2Config {
+				rounds: params.and_then(|p| p.rounds).unwrap_or(1000),
+				output_length: params.and_then(|p| p.output_length).unwrap_or(32),
+			},
+			&salt_b64(fixture.salt.as_ref().expect("salt")),
+		)
+		.expect("pbkdf2-sha256"),
+		"pbkdf2-sha512" => PHash::hash_pbkdf2_with_salt(
+			&password_str(fixture.password.as_ref().expect("password")),
+			"pbkdf2sha512",
+			&Pbkdf2Config {
+				rounds: params.and_then(|p| p.rounds).unwrap_or(1000),
+				output_length: params.and_then(|p| p.output_length).unwrap_or(64),
+			},
+			&salt_b64(fixture.salt.as_ref().expect("salt")),
+		)
+		.expect("pbkdf2-sha512"),
+		"sha-crypt" => {
+			let salt = decode_bytes("salt", fixture.salt.as_ref().expect("salt"));
+			PHash::hash_sha_crypt_with_salt(
+				&password_str(fixture.password.as_ref().expect("password")),
+				&salt,
+			)
+			.expect("sha-crypt")
+		}
+		alg if alg.starts_with("hkdf-") => {
+			let algorithm = HkdfAlgorithm::from_str(alg).expect("hkdf algorithm");
+			let length = params.and_then(|p| p.length).unwrap_or(algorithm.output_size());
+			let resp = derive(HkdfRequest {
+				variant: HkdfVariant::new(algorithm, HkdfMode::ExtractAndExpand),
+				input: HkdfInput::Extract(SecretMaterial::from_bytes(decode_bytes(
+					"ikm",
+					fixture.ikm.as_ref().expect("ikm"),
+				))),
+				salt: fixture
+					.salt
+					.as_ref()
+					.map(|s| decode_bytes("salt", s))
+					.unwrap_or_default(),
+				info: fixture
+					.info
+					.as_ref()
+					.map(|s| decode_bytes("info", s))
+					.unwrap_or_default(),
+				length,
+			})
+			.expect("hkdf derive");
+			hex::encode(resp.derived_key)
+		}
+		other => panic!("unsupported KDF algorithm `{other}`"),
+	}
+}
+
+#[test]
+fn published_kdf_kats_match_implementations() {
+	for (path, fixture) in load_fixtures() {
+		let actual = derive_kat(&fixture);
+		assert_eq!(
+			actual, fixture.expected,
+			"KDF KAT mismatch for {} ({})",
+			fixture.algorithm,
+			path.display()
+		);
+	}
+}
+
+#[test]
+fn every_kdf_algorithm_id_has_a_published_kat() {
+	let covered: HashSet<String> = load_fixtures()
+		.into_iter()
+		.map(|(_, fixture)| fixture.algorithm)
+		.collect();
+	for alg in KDF_ALGORITHM_IDS {
+		assert!(
+			covered.contains(*alg),
+			"missing KDF KAT for {alg}"
+		);
+	}
+}
+
+#[test]
+fn kdf_kat_fixtures_have_no_orphan_algorithms() {
+	let known: HashSet<&str> = KDF_ALGORITHM_IDS.iter().copied().collect();
+	for (path, fixture) in load_fixtures() {
+		assert!(
+			known.contains(fixture.algorithm.as_str()),
+			"orphan KDF KAT {} in {}",
+			fixture.algorithm,
+			path.display()
+		);
+	}
+}

--- a/tests/mac_kats.rs
+++ b/tests/mac_kats.rs
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Project: rustgenhash
+
+use rustgenhash::rgh::mac::executor::{consume_bytes, digest_to_hex};
+use rustgenhash::rgh::mac::registry;
+use serde::Deserialize;
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Deserialize)]
+struct KatSource {
+	title: String,
+	url: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct KatInput {
+	encoding: String,
+	value: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct KatKey {
+	path: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct KatFixture {
+	algorithm: String,
+	key: KatKey,
+	input: KatInput,
+	expected_hex: String,
+	source: KatSource,
+}
+
+fn kats_dir() -> PathBuf {
+	PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/mac/kats")
+}
+
+fn load_fixtures() -> Vec<(PathBuf, KatFixture)> {
+	let mut entries = Vec::new();
+	for entry in fs::read_dir(kats_dir()).expect("mac kats directory") {
+		let entry = entry.expect("dir entry");
+		let path = entry.path();
+		if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+			continue;
+		}
+		let raw = fs::read_to_string(&path).unwrap_or_else(|err| {
+			panic!("read {}: {err}", path.display());
+		});
+		let fixture: KatFixture = serde_json::from_str(&raw).unwrap_or_else(|err| {
+			panic!("parse {}: {err}", path.display());
+		});
+		assert!(
+			!fixture.source.title.is_empty() && !fixture.source.url.is_empty(),
+			"{} missing source citation",
+			path.display()
+		);
+		entries.push((path, fixture));
+	}
+	entries.sort_by(|a, b| a.0.cmp(&b.0));
+	assert!(!entries.is_empty(), "no MAC KAT fixtures found");
+	entries
+}
+
+fn input_bytes(input: &KatInput) -> Vec<u8> {
+	match input.encoding.as_str() {
+		"utf8" => input.value.as_bytes().to_vec(),
+		"hex" => hex::decode(&input.value).expect("hex input"),
+		other => panic!("unsupported input encoding `{other}`"),
+	}
+}
+
+fn resolve_key(path: &str) -> Vec<u8> {
+	let full = if Path::new(path).is_absolute() {
+		PathBuf::from(path)
+	} else {
+		PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(path)
+	};
+	fs::read(&full).unwrap_or_else(|err| panic!("read key {}: {err}", full.display()))
+}
+
+#[test]
+fn published_mac_kats_match_registry_executors() {
+	for (path, fixture) in load_fixtures() {
+		let key = resolve_key(&fixture.key.path);
+		let data = input_bytes(&fixture.input);
+		let (executor, _) = registry::create_executor(&fixture.algorithm, &key)
+			.unwrap_or_else(|err| {
+				panic!(
+					"create_executor({}) failed for {}: {}",
+					fixture.algorithm,
+					path.display(),
+					err
+				);
+			});
+		let actual = digest_to_hex(&consume_bytes(&data, executor));
+		assert_eq!(
+			actual, fixture.expected_hex,
+			"MAC KAT mismatch for {} ({})",
+			fixture.algorithm,
+			path.display()
+		);
+	}
+}
+
+#[test]
+fn every_registry_mac_has_a_published_kat() {
+	let covered: HashSet<String> = load_fixtures()
+		.into_iter()
+		.map(|(_, fixture)| fixture.algorithm)
+		.collect();
+	for alg in registry::algorithms() {
+		assert!(
+			covered.contains(alg.metadata.identifier),
+			"missing MAC KAT for {}",
+			alg.metadata.identifier
+		);
+	}
+}
+
+#[test]
+fn mac_kat_fixtures_have_no_orphan_algorithms() {
+	let known: HashSet<&str> = registry::algorithms()
+		.map(|alg| alg.metadata.identifier)
+		.collect();
+	for (path, fixture) in load_fixtures() {
+		assert!(
+			known.contains(fixture.algorithm.as_str()),
+			"orphan MAC KAT {} in {}",
+			fixture.algorithm,
+			path.display()
+		);
+	}
+}


### PR DESCRIPTION
## Summary
- Sourced MAC and KDF known-answer fixtures with coverage gates (`mac_kats`, `kdf_kats`)
- Drift test: digest-capable `Algorithm` variants stay in `DIGEST_ALGORITHMS`; non-empty `abc` digest KATs
- Sort lowercased header names for `hhh:1:`; document `compare_hashes` display semantics

## Test plan
- [ ] `cargo test --test digest_kats --test mac_kats --test kdf_kats`
- [ ] `cargo test --lib digest_capable_algorithms_are_in_digest_registry`
- [ ] `cargo test --lib header_order_does_not_change_hhhash`
